### PR TITLE
Harden library: credential safety, silent-failure fixes, telemetry

### DIFF
--- a/lib/pubsub_grpc.ex
+++ b/lib/pubsub_grpc.ex
@@ -59,7 +59,7 @@ defmodule PubsubGrpc do
 
   """
 
-  alias PubsubGrpc.{Client, Error, Schema, Validation}
+  alias PubsubGrpc.{Client, Error, Result, Schema, Telemetry, Validation}
 
   # Topics
 
@@ -79,18 +79,20 @@ defmodule PubsubGrpc do
   @spec create_topic(String.t(), String.t()) ::
           {:ok, Google.Pubsub.V1.Topic.t()} | {:error, Error.t()}
   def create_topic(project_id, topic_id) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_topic_id(topic_id),
-         {:ok, grpc_opts} <- grpc_opts() do
-      topic_path = topic_path(project_id, topic_id)
+    Telemetry.span(:create_topic, %{project_id: project_id, topic_id: topic_id}, fn ->
+      with {:ok, _} <- Validation.validate_project_id(project_id),
+           {:ok, _} <- Validation.validate_topic_id(topic_id),
+           {:ok, grpc_opts} <- grpc_opts() do
+        topic_path = topic_path(project_id, topic_id)
 
-      fn channel ->
-        request = %Google.Pubsub.V1.Topic{name: topic_path}
-        Google.Pubsub.V1.Publisher.Stub.create_topic(channel, request, grpc_opts)
+        fn channel ->
+          request = %Google.Pubsub.V1.Topic{name: topic_path}
+          Google.Pubsub.V1.Publisher.Stub.create_topic(channel, request, grpc_opts)
+        end
+        |> Client.execute()
+        |> Result.unwrap()
       end
-      |> Client.execute()
-      |> unwrap_result()
-    end
+    end)
   end
 
   @doc """
@@ -104,18 +106,20 @@ defmodule PubsubGrpc do
   @spec get_topic(String.t(), String.t()) ::
           {:ok, Google.Pubsub.V1.Topic.t()} | {:error, Error.t()}
   def get_topic(project_id, topic_id) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_topic_id(topic_id),
-         {:ok, grpc_opts} <- grpc_opts() do
-      topic_path = topic_path(project_id, topic_id)
+    Telemetry.span(:get_topic, %{project_id: project_id, topic_id: topic_id}, fn ->
+      with {:ok, _} <- Validation.validate_project_id(project_id),
+           {:ok, _} <- Validation.validate_topic_id(topic_id),
+           {:ok, grpc_opts} <- grpc_opts() do
+        topic_path = topic_path(project_id, topic_id)
 
-      fn channel ->
-        request = %Google.Pubsub.V1.GetTopicRequest{topic: topic_path}
-        Google.Pubsub.V1.Publisher.Stub.get_topic(channel, request, grpc_opts)
+        fn channel ->
+          request = %Google.Pubsub.V1.GetTopicRequest{topic: topic_path}
+          Google.Pubsub.V1.Publisher.Stub.get_topic(channel, request, grpc_opts)
+        end
+        |> Client.execute()
+        |> Result.unwrap()
       end
-      |> Client.execute()
-      |> unwrap_result()
-    end
+    end)
   end
 
   @doc """
@@ -128,18 +132,20 @@ defmodule PubsubGrpc do
   """
   @spec delete_topic(String.t(), String.t()) :: :ok | {:error, Error.t()}
   def delete_topic(project_id, topic_id) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_topic_id(topic_id),
-         {:ok, grpc_opts} <- grpc_opts() do
-      topic_path = topic_path(project_id, topic_id)
+    Telemetry.span(:delete_topic, %{project_id: project_id, topic_id: topic_id}, fn ->
+      with {:ok, _} <- Validation.validate_project_id(project_id),
+           {:ok, _} <- Validation.validate_topic_id(topic_id),
+           {:ok, grpc_opts} <- grpc_opts() do
+        topic_path = topic_path(project_id, topic_id)
 
-      fn channel ->
-        request = %Google.Pubsub.V1.DeleteTopicRequest{topic: topic_path}
-        Google.Pubsub.V1.Publisher.Stub.delete_topic(channel, request, grpc_opts)
+        fn channel ->
+          request = %Google.Pubsub.V1.DeleteTopicRequest{topic: topic_path}
+          Google.Pubsub.V1.Publisher.Stub.delete_topic(channel, request, grpc_opts)
+        end
+        |> Client.execute()
+        |> Result.unwrap_empty()
       end
-      |> Client.execute()
-      |> unwrap_empty_result()
-    end
+    end)
   end
 
   @doc """
@@ -156,22 +162,24 @@ defmodule PubsubGrpc do
   @spec list_topics(String.t(), keyword()) ::
           {:ok, %{topics: list(), next_page_token: String.t()}} | {:error, Error.t()}
   def list_topics(project_id, opts \\ []) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, grpc_opts} <- grpc_opts() do
-      project_path = "projects/#{project_id}"
+    Telemetry.span(:list_topics, %{project_id: project_id}, fn ->
+      with {:ok, _} <- Validation.validate_project_id(project_id),
+           {:ok, grpc_opts} <- grpc_opts(opts) do
+        project_path = "projects/#{project_id}"
 
-      fn channel ->
-        request = %Google.Pubsub.V1.ListTopicsRequest{
-          project: project_path,
-          page_size: Keyword.get(opts, :page_size, 0),
-          page_token: Keyword.get(opts, :page_token, "")
-        }
+        fn channel ->
+          request = %Google.Pubsub.V1.ListTopicsRequest{
+            project: project_path,
+            page_size: Keyword.get(opts, :page_size, 0),
+            page_token: Keyword.get(opts, :page_token, "")
+          }
 
-        Google.Pubsub.V1.Publisher.Stub.list_topics(channel, request, grpc_opts)
+          Google.Pubsub.V1.Publisher.Stub.list_topics(channel, request, grpc_opts)
+        end
+        |> Client.execute()
+        |> Result.unwrap_list(:topics, :next_page_token)
       end
-      |> Client.execute()
-      |> unwrap_list_result(:topics, :next_page_token)
-    end
+    end)
   end
 
   # Publishing
@@ -195,37 +203,45 @@ defmodule PubsubGrpc do
       {:ok, response} = PubsubGrpc.publish("my-project", "my-topic", messages)
 
   """
-  @spec publish(String.t(), String.t(), [map()]) ::
+  @spec publish(String.t(), String.t(), [map()], keyword()) ::
           {:ok, %{message_ids: [String.t()]}} | {:error, Error.t()}
-  def publish(project_id, topic_id, messages) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_topic_id(topic_id),
-         {:ok, _} <- Validation.validate_messages(messages),
-         {:ok, grpc_opts} <- grpc_opts() do
-      topic_path = topic_path(project_id, topic_id)
+  def publish(project_id, topic_id, messages, opts \\ []) do
+    message_count = if is_list(messages), do: length(messages), else: 0
 
-      pubsub_messages =
-        Enum.map(messages, fn msg ->
-          %Google.Pubsub.V1.PubsubMessage{
-            data: Map.get(msg, :data, ""),
-            attributes: Map.get(msg, :attributes, %{})
-          }
-        end)
+    Telemetry.span(
+      :publish,
+      %{project_id: project_id, topic_id: topic_id, message_count: message_count},
+      fn ->
+        with {:ok, _} <- Validation.validate_project_id(project_id),
+             {:ok, _} <- Validation.validate_topic_id(topic_id),
+             {:ok, _} <- Validation.validate_messages(messages),
+             {:ok, grpc_opts} <- grpc_opts(opts) do
+          topic_path = topic_path(project_id, topic_id)
 
-      fn channel ->
-        request = %Google.Pubsub.V1.PublishRequest{
-          topic: topic_path,
-          messages: pubsub_messages
-        }
+          pubsub_messages =
+            Enum.map(messages, fn msg ->
+              %Google.Pubsub.V1.PubsubMessage{
+                data: Map.get(msg, :data, ""),
+                attributes: Map.get(msg, :attributes, %{})
+              }
+            end)
 
-        Google.Pubsub.V1.Publisher.Stub.publish(channel, request, grpc_opts)
+          fn channel ->
+            request = %Google.Pubsub.V1.PublishRequest{
+              topic: topic_path,
+              messages: pubsub_messages
+            }
+
+            Google.Pubsub.V1.Publisher.Stub.publish(channel, request, grpc_opts)
+          end
+          |> Client.execute()
+          |> case do
+            {:ok, {:ok, response}} -> {:ok, %{message_ids: response.message_ids}}
+            other -> Result.unwrap_error(other)
+          end
+        end
       end
-      |> Client.execute()
-      |> case do
-        {:ok, {:ok, response}} -> {:ok, %{message_ids: response.message_ids}}
-        other -> unwrap_error(other)
-      end
-    end
+    )
   end
 
   @doc """
@@ -251,26 +267,36 @@ defmodule PubsubGrpc do
   def create_subscription(project_id, topic_id, subscription_id, opts \\ []) do
     ack_deadline = Keyword.get(opts, :ack_deadline_seconds, 60)
 
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_topic_id(topic_id),
-         {:ok, _} <- Validation.validate_subscription_id(subscription_id),
-         {:ok, _} <- Validation.validate_ack_deadline(ack_deadline),
-         {:ok, grpc_opts} <- grpc_opts() do
-      topic_path = topic_path(project_id, topic_id)
-      subscription_path = subscription_path(project_id, subscription_id)
+    Telemetry.span(
+      :create_subscription,
+      %{
+        project_id: project_id,
+        topic_id: topic_id,
+        subscription_id: subscription_id
+      },
+      fn ->
+        with {:ok, _} <- Validation.validate_project_id(project_id),
+             {:ok, _} <- Validation.validate_topic_id(topic_id),
+             {:ok, _} <- Validation.validate_subscription_id(subscription_id),
+             {:ok, _} <- Validation.validate_ack_deadline(ack_deadline),
+             {:ok, grpc_opts} <- grpc_opts(opts) do
+          topic_path = topic_path(project_id, topic_id)
+          subscription_path = subscription_path(project_id, subscription_id)
 
-      fn channel ->
-        request = %Google.Pubsub.V1.Subscription{
-          name: subscription_path,
-          topic: topic_path,
-          ack_deadline_seconds: ack_deadline
-        }
+          fn channel ->
+            request = %Google.Pubsub.V1.Subscription{
+              name: subscription_path,
+              topic: topic_path,
+              ack_deadline_seconds: ack_deadline
+            }
 
-        Google.Pubsub.V1.Subscriber.Stub.create_subscription(channel, request, grpc_opts)
+            Google.Pubsub.V1.Subscriber.Stub.create_subscription(channel, request, grpc_opts)
+          end
+          |> Client.execute()
+          |> Result.unwrap()
+        end
       end
-      |> Client.execute()
-      |> unwrap_result()
-    end
+    )
   end
 
   @doc """
@@ -284,18 +310,24 @@ defmodule PubsubGrpc do
   @spec get_subscription(String.t(), String.t()) ::
           {:ok, Google.Pubsub.V1.Subscription.t()} | {:error, Error.t()}
   def get_subscription(project_id, subscription_id) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_subscription_id(subscription_id),
-         {:ok, grpc_opts} <- grpc_opts() do
-      subscription_path = subscription_path(project_id, subscription_id)
+    Telemetry.span(
+      :get_subscription,
+      %{project_id: project_id, subscription_id: subscription_id},
+      fn ->
+        with {:ok, _} <- Validation.validate_project_id(project_id),
+             {:ok, _} <- Validation.validate_subscription_id(subscription_id),
+             {:ok, grpc_opts} <- grpc_opts() do
+          subscription_path = subscription_path(project_id, subscription_id)
 
-      fn channel ->
-        request = %Google.Pubsub.V1.GetSubscriptionRequest{subscription: subscription_path}
-        Google.Pubsub.V1.Subscriber.Stub.get_subscription(channel, request, grpc_opts)
+          fn channel ->
+            request = %Google.Pubsub.V1.GetSubscriptionRequest{subscription: subscription_path}
+            Google.Pubsub.V1.Subscriber.Stub.get_subscription(channel, request, grpc_opts)
+          end
+          |> Client.execute()
+          |> Result.unwrap()
+        end
       end
-      |> Client.execute()
-      |> unwrap_result()
-    end
+    )
   end
 
   @doc """
@@ -307,18 +339,24 @@ defmodule PubsubGrpc do
   """
   @spec delete_subscription(String.t(), String.t()) :: :ok | {:error, Error.t()}
   def delete_subscription(project_id, subscription_id) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_subscription_id(subscription_id),
-         {:ok, grpc_opts} <- grpc_opts() do
-      subscription_path = subscription_path(project_id, subscription_id)
+    Telemetry.span(
+      :delete_subscription,
+      %{project_id: project_id, subscription_id: subscription_id},
+      fn ->
+        with {:ok, _} <- Validation.validate_project_id(project_id),
+             {:ok, _} <- Validation.validate_subscription_id(subscription_id),
+             {:ok, grpc_opts} <- grpc_opts() do
+          subscription_path = subscription_path(project_id, subscription_id)
 
-      fn channel ->
-        request = %Google.Pubsub.V1.DeleteSubscriptionRequest{subscription: subscription_path}
-        Google.Pubsub.V1.Subscriber.Stub.delete_subscription(channel, request, grpc_opts)
+          fn channel ->
+            request = %Google.Pubsub.V1.DeleteSubscriptionRequest{subscription: subscription_path}
+            Google.Pubsub.V1.Subscriber.Stub.delete_subscription(channel, request, grpc_opts)
+          end
+          |> Client.execute()
+          |> Result.unwrap_empty()
+        end
       end
-      |> Client.execute()
-      |> unwrap_empty_result()
-    end
+    )
   end
 
   @doc """
@@ -335,22 +373,24 @@ defmodule PubsubGrpc do
   @spec list_subscriptions(String.t(), keyword()) ::
           {:ok, %{subscriptions: list(), next_page_token: String.t()}} | {:error, Error.t()}
   def list_subscriptions(project_id, opts \\ []) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, grpc_opts} <- grpc_opts() do
-      project_path = "projects/#{project_id}"
+    Telemetry.span(:list_subscriptions, %{project_id: project_id}, fn ->
+      with {:ok, _} <- Validation.validate_project_id(project_id),
+           {:ok, grpc_opts} <- grpc_opts(opts) do
+        project_path = "projects/#{project_id}"
 
-      fn channel ->
-        request = %Google.Pubsub.V1.ListSubscriptionsRequest{
-          project: project_path,
-          page_size: Keyword.get(opts, :page_size, 0),
-          page_token: Keyword.get(opts, :page_token, "")
-        }
+        fn channel ->
+          request = %Google.Pubsub.V1.ListSubscriptionsRequest{
+            project: project_path,
+            page_size: Keyword.get(opts, :page_size, 0),
+            page_token: Keyword.get(opts, :page_token, "")
+          }
 
-        Google.Pubsub.V1.Subscriber.Stub.list_subscriptions(channel, request, grpc_opts)
+          Google.Pubsub.V1.Subscriber.Stub.list_subscriptions(channel, request, grpc_opts)
+        end
+        |> Client.execute()
+        |> Result.unwrap_list(:subscriptions, :next_page_token)
       end
-      |> Client.execute()
-      |> unwrap_list_result(:subscriptions, :next_page_token)
-    end
+    end)
   end
 
   # Message Operations
@@ -365,29 +405,39 @@ defmodule PubsubGrpc do
   - `{:ok, [%Google.Pubsub.V1.ReceivedMessage{}]}`
 
   """
-  @spec pull(String.t(), String.t(), pos_integer()) ::
+  @spec pull(String.t(), String.t(), pos_integer(), keyword()) ::
           {:ok, list()} | {:error, Error.t()}
-  def pull(project_id, subscription_id, max_messages \\ 10) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_subscription_id(subscription_id),
-         {:ok, _} <- Validation.validate_max_messages(max_messages),
-         {:ok, grpc_opts} <- grpc_opts() do
-      subscription_path = subscription_path(project_id, subscription_id)
+  def pull(project_id, subscription_id, max_messages \\ 10, opts \\ []) do
+    Telemetry.span(
+      :pull,
+      %{
+        project_id: project_id,
+        subscription_id: subscription_id,
+        max_messages: max_messages
+      },
+      fn ->
+        with {:ok, _} <- Validation.validate_project_id(project_id),
+             {:ok, _} <- Validation.validate_subscription_id(subscription_id),
+             {:ok, _} <- Validation.validate_max_messages(max_messages),
+             {:ok, grpc_opts} <- grpc_opts(opts) do
+          subscription_path = subscription_path(project_id, subscription_id)
 
-      fn channel ->
-        request = %Google.Pubsub.V1.PullRequest{
-          subscription: subscription_path,
-          max_messages: max_messages
-        }
+          fn channel ->
+            request = %Google.Pubsub.V1.PullRequest{
+              subscription: subscription_path,
+              max_messages: max_messages
+            }
 
-        Google.Pubsub.V1.Subscriber.Stub.pull(channel, request, grpc_opts)
+            Google.Pubsub.V1.Subscriber.Stub.pull(channel, request, grpc_opts)
+          end
+          |> Client.execute()
+          |> case do
+            {:ok, {:ok, response}} -> {:ok, response.received_messages}
+            other -> Result.unwrap_error(other)
+          end
+        end
       end
-      |> Client.execute()
-      |> case do
-        {:ok, {:ok, response}} -> {:ok, response.received_messages}
-        other -> unwrap_error(other)
-      end
-    end
+    )
   end
 
   @doc """
@@ -400,25 +450,38 @@ defmodule PubsubGrpc do
   - `:ok` on success
 
   """
-  @spec acknowledge(String.t(), String.t(), [String.t()]) :: :ok | {:error, Error.t()}
-  def acknowledge(project_id, subscription_id, ack_ids) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_subscription_id(subscription_id),
-         {:ok, _} <- Validation.validate_ack_ids(ack_ids),
-         {:ok, grpc_opts} <- grpc_opts() do
-      subscription_path = subscription_path(project_id, subscription_id)
+  @spec acknowledge(String.t(), String.t(), [String.t()], keyword()) ::
+          :ok | {:error, Error.t()}
+  def acknowledge(project_id, subscription_id, ack_ids, opts \\ []) do
+    ack_count = if is_list(ack_ids), do: length(ack_ids), else: 0
 
-      fn channel ->
-        request = %Google.Pubsub.V1.AcknowledgeRequest{
-          subscription: subscription_path,
-          ack_ids: ack_ids
-        }
+    Telemetry.span(
+      :acknowledge,
+      %{
+        project_id: project_id,
+        subscription_id: subscription_id,
+        ack_count: ack_count
+      },
+      fn ->
+        with {:ok, _} <- Validation.validate_project_id(project_id),
+             {:ok, _} <- Validation.validate_subscription_id(subscription_id),
+             {:ok, _} <- Validation.validate_ack_ids(ack_ids),
+             {:ok, grpc_opts} <- grpc_opts(opts) do
+          subscription_path = subscription_path(project_id, subscription_id)
 
-        Google.Pubsub.V1.Subscriber.Stub.acknowledge(channel, request, grpc_opts)
+          fn channel ->
+            request = %Google.Pubsub.V1.AcknowledgeRequest{
+              subscription: subscription_path,
+              ack_ids: ack_ids
+            }
+
+            Google.Pubsub.V1.Subscriber.Stub.acknowledge(channel, request, grpc_opts)
+          end
+          |> Client.execute()
+          |> Result.unwrap_empty()
+        end
       end
-      |> Client.execute()
-      |> unwrap_empty_result()
-    end
+    )
   end
 
   @doc """
@@ -435,28 +498,47 @@ defmodule PubsubGrpc do
   - `:ok` on success
 
   """
-  @spec modify_ack_deadline(String.t(), String.t(), [String.t()], non_neg_integer()) ::
+  @spec modify_ack_deadline(
+          String.t(),
+          String.t(),
+          [String.t()],
+          non_neg_integer(),
+          keyword()
+        ) ::
           :ok | {:error, Error.t()}
-  def modify_ack_deadline(project_id, subscription_id, ack_ids, ack_deadline_seconds) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_subscription_id(subscription_id),
-         {:ok, _} <- Validation.validate_ack_ids(ack_ids),
-         {:ok, _} <- Validation.validate_ack_deadline_with_zero(ack_deadline_seconds),
-         {:ok, grpc_opts} <- grpc_opts() do
-      subscription_path = subscription_path(project_id, subscription_id)
+  def modify_ack_deadline(project_id, subscription_id, ack_ids, ack_deadline_seconds, opts \\ []) do
+    ack_count = if is_list(ack_ids), do: length(ack_ids), else: 0
 
-      fn channel ->
-        request = %Google.Pubsub.V1.ModifyAckDeadlineRequest{
-          subscription: subscription_path,
-          ack_ids: ack_ids,
-          ack_deadline_seconds: ack_deadline_seconds
-        }
+    Telemetry.span(
+      :modify_ack_deadline,
+      %{
+        project_id: project_id,
+        subscription_id: subscription_id,
+        ack_count: ack_count,
+        ack_deadline_seconds: ack_deadline_seconds
+      },
+      fn ->
+        with {:ok, _} <- Validation.validate_project_id(project_id),
+             {:ok, _} <- Validation.validate_subscription_id(subscription_id),
+             {:ok, _} <- Validation.validate_ack_ids(ack_ids),
+             {:ok, _} <- Validation.validate_ack_deadline_with_zero(ack_deadline_seconds),
+             {:ok, grpc_opts} <- grpc_opts(opts) do
+          subscription_path = subscription_path(project_id, subscription_id)
 
-        Google.Pubsub.V1.Subscriber.Stub.modify_ack_deadline(channel, request, grpc_opts)
+          fn channel ->
+            request = %Google.Pubsub.V1.ModifyAckDeadlineRequest{
+              subscription: subscription_path,
+              ack_ids: ack_ids,
+              ack_deadline_seconds: ack_deadline_seconds
+            }
+
+            Google.Pubsub.V1.Subscriber.Stub.modify_ack_deadline(channel, request, grpc_opts)
+          end
+          |> Client.execute()
+          |> Result.unwrap_empty()
+        end
       end
-      |> Client.execute()
-      |> unwrap_empty_result()
-    end
+    )
   end
 
   @doc """
@@ -471,9 +553,9 @@ defmodule PubsubGrpc do
   - `:ok` on success
 
   """
-  @spec nack(String.t(), String.t(), [String.t()]) :: :ok | {:error, Error.t()}
-  def nack(project_id, subscription_id, ack_ids) do
-    modify_ack_deadline(project_id, subscription_id, ack_ids, 0)
+  @spec nack(String.t(), String.t(), [String.t()], keyword()) :: :ok | {:error, Error.t()}
+  def nack(project_id, subscription_id, ack_ids, opts \\ []) do
+    modify_ack_deadline(project_id, subscription_id, ack_ids, 0, opts)
   end
 
   # Custom Operations
@@ -498,7 +580,7 @@ defmodule PubsubGrpc do
   @spec execute((GRPC.Channel.t() -> term()), keyword()) ::
           {:ok, term()} | {:error, Error.t()}
   def execute(operation_fn, opts \\ []) when is_function(operation_fn, 1) do
-    Client.execute(operation_fn, opts) |> unwrap_result()
+    Client.execute(operation_fn, opts) |> Result.unwrap()
   end
 
   @doc """
@@ -517,7 +599,7 @@ defmodule PubsubGrpc do
   @spec with_connection((GRPC.Channel.t() -> term()), keyword()) ::
           {:ok, term()} | {:error, Error.t()}
   def with_connection(fun, opts \\ []) when is_function(fun, 1) do
-    Client.execute(fun, opts) |> unwrap_result()
+    Client.execute(fun, opts) |> Result.unwrap()
   end
 
   # Schema management (delegated)
@@ -593,11 +675,11 @@ defmodule PubsubGrpc do
 
   # Private helpers
 
-  defp grpc_opts do
-    timeout = Application.get_env(:pubsub_grpc, :default_timeout, 30_000)
+  defp grpc_opts(opts \\ []) do
+    timeout = opts[:timeout] || Application.get_env(:pubsub_grpc, :default_timeout, 30_000)
 
     case PubsubGrpc.Auth.request_opts() do
-      {:ok, opts} -> {:ok, opts ++ [timeout: timeout]}
+      {:ok, auth_opts} -> {:ok, auth_opts ++ [timeout: timeout]}
       {:error, _} = error -> error
     end
   end
@@ -608,29 +690,5 @@ defmodule PubsubGrpc do
 
   defp subscription_path(project_id, subscription_id) do
     "projects/#{project_id}/subscriptions/#{subscription_id}"
-  end
-
-  defp unwrap_result({:ok, {:ok, result}}), do: {:ok, result}
-  defp unwrap_result(other), do: unwrap_error(other)
-
-  defp unwrap_empty_result({:ok, {:ok, %Google.Protobuf.Empty{}}}), do: :ok
-  defp unwrap_empty_result(other), do: unwrap_error(other)
-
-  defp unwrap_list_result({:ok, {:ok, response}}, items_key, token_key) do
-    {:ok, %{items_key => Map.get(response, items_key), token_key => Map.get(response, token_key)}}
-  end
-
-  defp unwrap_list_result(other, _items_key, _token_key), do: unwrap_error(other)
-
-  defp unwrap_error({:ok, {:error, %GRPC.RPCError{} = error}}) do
-    {:error, Error.from_grpc_error(error)}
-  end
-
-  defp unwrap_error({:ok, {:error, error}}) do
-    {:error, Error.new(:internal, "unexpected error: #{inspect(error)}", error)}
-  end
-
-  defp unwrap_error({:error, reason}) do
-    {:error, Error.new(:connection_error, "connection error: #{inspect(reason)}", reason)}
   end
 end

--- a/lib/pubsub_grpc.ex
+++ b/lib/pubsub_grpc.ex
@@ -80,19 +80,23 @@ defmodule PubsubGrpc do
           {:ok, Google.Pubsub.V1.Topic.t()} | {:error, Error.t()}
   def create_topic(project_id, topic_id) do
     Telemetry.span(:create_topic, %{project_id: project_id, topic_id: topic_id}, fn ->
-      with {:ok, _} <- Validation.validate_project_id(project_id),
-           {:ok, _} <- Validation.validate_topic_id(topic_id),
-           {:ok, grpc_opts} <- grpc_opts() do
-        topic_path = topic_path(project_id, topic_id)
-
-        fn channel ->
-          request = %Google.Pubsub.V1.Topic{name: topic_path}
-          Google.Pubsub.V1.Publisher.Stub.create_topic(channel, request, grpc_opts)
-        end
-        |> Client.execute()
-        |> Result.unwrap()
-      end
+      do_create_topic(project_id, topic_id)
     end)
+  end
+
+  defp do_create_topic(project_id, topic_id) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_topic_id(topic_id),
+         {:ok, grpc_opts} <- grpc_opts() do
+      topic_path = topic_path(project_id, topic_id)
+
+      fn channel ->
+        request = %Google.Pubsub.V1.Topic{name: topic_path}
+        Google.Pubsub.V1.Publisher.Stub.create_topic(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap()
+    end
   end
 
   @doc """
@@ -107,19 +111,23 @@ defmodule PubsubGrpc do
           {:ok, Google.Pubsub.V1.Topic.t()} | {:error, Error.t()}
   def get_topic(project_id, topic_id) do
     Telemetry.span(:get_topic, %{project_id: project_id, topic_id: topic_id}, fn ->
-      with {:ok, _} <- Validation.validate_project_id(project_id),
-           {:ok, _} <- Validation.validate_topic_id(topic_id),
-           {:ok, grpc_opts} <- grpc_opts() do
-        topic_path = topic_path(project_id, topic_id)
-
-        fn channel ->
-          request = %Google.Pubsub.V1.GetTopicRequest{topic: topic_path}
-          Google.Pubsub.V1.Publisher.Stub.get_topic(channel, request, grpc_opts)
-        end
-        |> Client.execute()
-        |> Result.unwrap()
-      end
+      do_get_topic(project_id, topic_id)
     end)
+  end
+
+  defp do_get_topic(project_id, topic_id) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_topic_id(topic_id),
+         {:ok, grpc_opts} <- grpc_opts() do
+      topic_path = topic_path(project_id, topic_id)
+
+      fn channel ->
+        request = %Google.Pubsub.V1.GetTopicRequest{topic: topic_path}
+        Google.Pubsub.V1.Publisher.Stub.get_topic(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap()
+    end
   end
 
   @doc """
@@ -133,19 +141,23 @@ defmodule PubsubGrpc do
   @spec delete_topic(String.t(), String.t()) :: :ok | {:error, Error.t()}
   def delete_topic(project_id, topic_id) do
     Telemetry.span(:delete_topic, %{project_id: project_id, topic_id: topic_id}, fn ->
-      with {:ok, _} <- Validation.validate_project_id(project_id),
-           {:ok, _} <- Validation.validate_topic_id(topic_id),
-           {:ok, grpc_opts} <- grpc_opts() do
-        topic_path = topic_path(project_id, topic_id)
-
-        fn channel ->
-          request = %Google.Pubsub.V1.DeleteTopicRequest{topic: topic_path}
-          Google.Pubsub.V1.Publisher.Stub.delete_topic(channel, request, grpc_opts)
-        end
-        |> Client.execute()
-        |> Result.unwrap_empty()
-      end
+      do_delete_topic(project_id, topic_id)
     end)
+  end
+
+  defp do_delete_topic(project_id, topic_id) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_topic_id(topic_id),
+         {:ok, grpc_opts} <- grpc_opts() do
+      topic_path = topic_path(project_id, topic_id)
+
+      fn channel ->
+        request = %Google.Pubsub.V1.DeleteTopicRequest{topic: topic_path}
+        Google.Pubsub.V1.Publisher.Stub.delete_topic(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap_empty()
+    end
   end
 
   @doc """
@@ -163,23 +175,27 @@ defmodule PubsubGrpc do
           {:ok, %{topics: list(), next_page_token: String.t()}} | {:error, Error.t()}
   def list_topics(project_id, opts \\ []) do
     Telemetry.span(:list_topics, %{project_id: project_id}, fn ->
-      with {:ok, _} <- Validation.validate_project_id(project_id),
-           {:ok, grpc_opts} <- grpc_opts(opts) do
-        project_path = "projects/#{project_id}"
-
-        fn channel ->
-          request = %Google.Pubsub.V1.ListTopicsRequest{
-            project: project_path,
-            page_size: Keyword.get(opts, :page_size, 0),
-            page_token: Keyword.get(opts, :page_token, "")
-          }
-
-          Google.Pubsub.V1.Publisher.Stub.list_topics(channel, request, grpc_opts)
-        end
-        |> Client.execute()
-        |> Result.unwrap_list(:topics, :next_page_token)
-      end
+      do_list_topics(project_id, opts)
     end)
+  end
+
+  defp do_list_topics(project_id, opts) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, grpc_opts} <- grpc_opts(opts) do
+      project_path = "projects/#{project_id}"
+
+      fn channel ->
+        request = %Google.Pubsub.V1.ListTopicsRequest{
+          project: project_path,
+          page_size: Keyword.get(opts, :page_size, 0),
+          page_token: Keyword.get(opts, :page_token, "")
+        }
+
+        Google.Pubsub.V1.Publisher.Stub.list_topics(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap_list(:topics, :next_page_token)
+    end
   end
 
   # Publishing
@@ -211,37 +227,39 @@ defmodule PubsubGrpc do
     Telemetry.span(
       :publish,
       %{project_id: project_id, topic_id: topic_id, message_count: message_count},
-      fn ->
-        with {:ok, _} <- Validation.validate_project_id(project_id),
-             {:ok, _} <- Validation.validate_topic_id(topic_id),
-             {:ok, _} <- Validation.validate_messages(messages),
-             {:ok, grpc_opts} <- grpc_opts(opts) do
-          topic_path = topic_path(project_id, topic_id)
-
-          pubsub_messages =
-            Enum.map(messages, fn msg ->
-              %Google.Pubsub.V1.PubsubMessage{
-                data: Map.get(msg, :data, ""),
-                attributes: Map.get(msg, :attributes, %{})
-              }
-            end)
-
-          fn channel ->
-            request = %Google.Pubsub.V1.PublishRequest{
-              topic: topic_path,
-              messages: pubsub_messages
-            }
-
-            Google.Pubsub.V1.Publisher.Stub.publish(channel, request, grpc_opts)
-          end
-          |> Client.execute()
-          |> case do
-            {:ok, {:ok, response}} -> {:ok, %{message_ids: response.message_ids}}
-            other -> Result.unwrap_error(other)
-          end
-        end
-      end
+      fn -> do_publish(project_id, topic_id, messages, opts) end
     )
+  end
+
+  defp do_publish(project_id, topic_id, messages, opts) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_topic_id(topic_id),
+         {:ok, _} <- Validation.validate_messages(messages),
+         {:ok, grpc_opts} <- grpc_opts(opts) do
+      topic_path = topic_path(project_id, topic_id)
+
+      pubsub_messages =
+        Enum.map(messages, fn msg ->
+          %Google.Pubsub.V1.PubsubMessage{
+            data: Map.get(msg, :data, ""),
+            attributes: Map.get(msg, :attributes, %{})
+          }
+        end)
+
+      fn channel ->
+        request = %Google.Pubsub.V1.PublishRequest{
+          topic: topic_path,
+          messages: pubsub_messages
+        }
+
+        Google.Pubsub.V1.Publisher.Stub.publish(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> case do
+        {:ok, {:ok, response}} -> {:ok, %{message_ids: response.message_ids}}
+        other -> Result.unwrap_error(other)
+      end
+    end
   end
 
   @doc """
@@ -265,8 +283,6 @@ defmodule PubsubGrpc do
   @spec create_subscription(String.t(), String.t(), String.t(), keyword()) ::
           {:ok, Google.Pubsub.V1.Subscription.t()} | {:error, Error.t()}
   def create_subscription(project_id, topic_id, subscription_id, opts \\ []) do
-    ack_deadline = Keyword.get(opts, :ack_deadline_seconds, 60)
-
     Telemetry.span(
       :create_subscription,
       %{
@@ -274,29 +290,33 @@ defmodule PubsubGrpc do
         topic_id: topic_id,
         subscription_id: subscription_id
       },
-      fn ->
-        with {:ok, _} <- Validation.validate_project_id(project_id),
-             {:ok, _} <- Validation.validate_topic_id(topic_id),
-             {:ok, _} <- Validation.validate_subscription_id(subscription_id),
-             {:ok, _} <- Validation.validate_ack_deadline(ack_deadline),
-             {:ok, grpc_opts} <- grpc_opts(opts) do
-          topic_path = topic_path(project_id, topic_id)
-          subscription_path = subscription_path(project_id, subscription_id)
-
-          fn channel ->
-            request = %Google.Pubsub.V1.Subscription{
-              name: subscription_path,
-              topic: topic_path,
-              ack_deadline_seconds: ack_deadline
-            }
-
-            Google.Pubsub.V1.Subscriber.Stub.create_subscription(channel, request, grpc_opts)
-          end
-          |> Client.execute()
-          |> Result.unwrap()
-        end
-      end
+      fn -> do_create_subscription(project_id, topic_id, subscription_id, opts) end
     )
+  end
+
+  defp do_create_subscription(project_id, topic_id, subscription_id, opts) do
+    ack_deadline = Keyword.get(opts, :ack_deadline_seconds, 60)
+
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_topic_id(topic_id),
+         {:ok, _} <- Validation.validate_subscription_id(subscription_id),
+         {:ok, _} <- Validation.validate_ack_deadline(ack_deadline),
+         {:ok, grpc_opts} <- grpc_opts(opts) do
+      topic_path = topic_path(project_id, topic_id)
+      subscription_path = subscription_path(project_id, subscription_id)
+
+      fn channel ->
+        request = %Google.Pubsub.V1.Subscription{
+          name: subscription_path,
+          topic: topic_path,
+          ack_deadline_seconds: ack_deadline
+        }
+
+        Google.Pubsub.V1.Subscriber.Stub.create_subscription(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap()
+    end
   end
 
   @doc """
@@ -313,21 +333,23 @@ defmodule PubsubGrpc do
     Telemetry.span(
       :get_subscription,
       %{project_id: project_id, subscription_id: subscription_id},
-      fn ->
-        with {:ok, _} <- Validation.validate_project_id(project_id),
-             {:ok, _} <- Validation.validate_subscription_id(subscription_id),
-             {:ok, grpc_opts} <- grpc_opts() do
-          subscription_path = subscription_path(project_id, subscription_id)
-
-          fn channel ->
-            request = %Google.Pubsub.V1.GetSubscriptionRequest{subscription: subscription_path}
-            Google.Pubsub.V1.Subscriber.Stub.get_subscription(channel, request, grpc_opts)
-          end
-          |> Client.execute()
-          |> Result.unwrap()
-        end
-      end
+      fn -> do_get_subscription(project_id, subscription_id) end
     )
+  end
+
+  defp do_get_subscription(project_id, subscription_id) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_subscription_id(subscription_id),
+         {:ok, grpc_opts} <- grpc_opts() do
+      subscription_path = subscription_path(project_id, subscription_id)
+
+      fn channel ->
+        request = %Google.Pubsub.V1.GetSubscriptionRequest{subscription: subscription_path}
+        Google.Pubsub.V1.Subscriber.Stub.get_subscription(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap()
+    end
   end
 
   @doc """
@@ -342,21 +364,23 @@ defmodule PubsubGrpc do
     Telemetry.span(
       :delete_subscription,
       %{project_id: project_id, subscription_id: subscription_id},
-      fn ->
-        with {:ok, _} <- Validation.validate_project_id(project_id),
-             {:ok, _} <- Validation.validate_subscription_id(subscription_id),
-             {:ok, grpc_opts} <- grpc_opts() do
-          subscription_path = subscription_path(project_id, subscription_id)
-
-          fn channel ->
-            request = %Google.Pubsub.V1.DeleteSubscriptionRequest{subscription: subscription_path}
-            Google.Pubsub.V1.Subscriber.Stub.delete_subscription(channel, request, grpc_opts)
-          end
-          |> Client.execute()
-          |> Result.unwrap_empty()
-        end
-      end
+      fn -> do_delete_subscription(project_id, subscription_id) end
     )
+  end
+
+  defp do_delete_subscription(project_id, subscription_id) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_subscription_id(subscription_id),
+         {:ok, grpc_opts} <- grpc_opts() do
+      subscription_path = subscription_path(project_id, subscription_id)
+
+      fn channel ->
+        request = %Google.Pubsub.V1.DeleteSubscriptionRequest{subscription: subscription_path}
+        Google.Pubsub.V1.Subscriber.Stub.delete_subscription(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap_empty()
+    end
   end
 
   @doc """
@@ -374,23 +398,27 @@ defmodule PubsubGrpc do
           {:ok, %{subscriptions: list(), next_page_token: String.t()}} | {:error, Error.t()}
   def list_subscriptions(project_id, opts \\ []) do
     Telemetry.span(:list_subscriptions, %{project_id: project_id}, fn ->
-      with {:ok, _} <- Validation.validate_project_id(project_id),
-           {:ok, grpc_opts} <- grpc_opts(opts) do
-        project_path = "projects/#{project_id}"
-
-        fn channel ->
-          request = %Google.Pubsub.V1.ListSubscriptionsRequest{
-            project: project_path,
-            page_size: Keyword.get(opts, :page_size, 0),
-            page_token: Keyword.get(opts, :page_token, "")
-          }
-
-          Google.Pubsub.V1.Subscriber.Stub.list_subscriptions(channel, request, grpc_opts)
-        end
-        |> Client.execute()
-        |> Result.unwrap_list(:subscriptions, :next_page_token)
-      end
+      do_list_subscriptions(project_id, opts)
     end)
+  end
+
+  defp do_list_subscriptions(project_id, opts) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, grpc_opts} <- grpc_opts(opts) do
+      project_path = "projects/#{project_id}"
+
+      fn channel ->
+        request = %Google.Pubsub.V1.ListSubscriptionsRequest{
+          project: project_path,
+          page_size: Keyword.get(opts, :page_size, 0),
+          page_token: Keyword.get(opts, :page_token, "")
+        }
+
+        Google.Pubsub.V1.Subscriber.Stub.list_subscriptions(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap_list(:subscriptions, :next_page_token)
+    end
   end
 
   # Message Operations
@@ -415,29 +443,31 @@ defmodule PubsubGrpc do
         subscription_id: subscription_id,
         max_messages: max_messages
       },
-      fn ->
-        with {:ok, _} <- Validation.validate_project_id(project_id),
-             {:ok, _} <- Validation.validate_subscription_id(subscription_id),
-             {:ok, _} <- Validation.validate_max_messages(max_messages),
-             {:ok, grpc_opts} <- grpc_opts(opts) do
-          subscription_path = subscription_path(project_id, subscription_id)
-
-          fn channel ->
-            request = %Google.Pubsub.V1.PullRequest{
-              subscription: subscription_path,
-              max_messages: max_messages
-            }
-
-            Google.Pubsub.V1.Subscriber.Stub.pull(channel, request, grpc_opts)
-          end
-          |> Client.execute()
-          |> case do
-            {:ok, {:ok, response}} -> {:ok, response.received_messages}
-            other -> Result.unwrap_error(other)
-          end
-        end
-      end
+      fn -> do_pull(project_id, subscription_id, max_messages, opts) end
     )
+  end
+
+  defp do_pull(project_id, subscription_id, max_messages, opts) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_subscription_id(subscription_id),
+         {:ok, _} <- Validation.validate_max_messages(max_messages),
+         {:ok, grpc_opts} <- grpc_opts(opts) do
+      subscription_path = subscription_path(project_id, subscription_id)
+
+      fn channel ->
+        request = %Google.Pubsub.V1.PullRequest{
+          subscription: subscription_path,
+          max_messages: max_messages
+        }
+
+        Google.Pubsub.V1.Subscriber.Stub.pull(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> case do
+        {:ok, {:ok, response}} -> {:ok, response.received_messages}
+        other -> Result.unwrap_error(other)
+      end
+    end
   end
 
   @doc """
@@ -462,26 +492,28 @@ defmodule PubsubGrpc do
         subscription_id: subscription_id,
         ack_count: ack_count
       },
-      fn ->
-        with {:ok, _} <- Validation.validate_project_id(project_id),
-             {:ok, _} <- Validation.validate_subscription_id(subscription_id),
-             {:ok, _} <- Validation.validate_ack_ids(ack_ids),
-             {:ok, grpc_opts} <- grpc_opts(opts) do
-          subscription_path = subscription_path(project_id, subscription_id)
-
-          fn channel ->
-            request = %Google.Pubsub.V1.AcknowledgeRequest{
-              subscription: subscription_path,
-              ack_ids: ack_ids
-            }
-
-            Google.Pubsub.V1.Subscriber.Stub.acknowledge(channel, request, grpc_opts)
-          end
-          |> Client.execute()
-          |> Result.unwrap_empty()
-        end
-      end
+      fn -> do_acknowledge(project_id, subscription_id, ack_ids, opts) end
     )
+  end
+
+  defp do_acknowledge(project_id, subscription_id, ack_ids, opts) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_subscription_id(subscription_id),
+         {:ok, _} <- Validation.validate_ack_ids(ack_ids),
+         {:ok, grpc_opts} <- grpc_opts(opts) do
+      subscription_path = subscription_path(project_id, subscription_id)
+
+      fn channel ->
+        request = %Google.Pubsub.V1.AcknowledgeRequest{
+          subscription: subscription_path,
+          ack_ids: ack_ids
+        }
+
+        Google.Pubsub.V1.Subscriber.Stub.acknowledge(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap_empty()
+    end
   end
 
   @doc """
@@ -518,27 +550,31 @@ defmodule PubsubGrpc do
         ack_deadline_seconds: ack_deadline_seconds
       },
       fn ->
-        with {:ok, _} <- Validation.validate_project_id(project_id),
-             {:ok, _} <- Validation.validate_subscription_id(subscription_id),
-             {:ok, _} <- Validation.validate_ack_ids(ack_ids),
-             {:ok, _} <- Validation.validate_ack_deadline_with_zero(ack_deadline_seconds),
-             {:ok, grpc_opts} <- grpc_opts(opts) do
-          subscription_path = subscription_path(project_id, subscription_id)
-
-          fn channel ->
-            request = %Google.Pubsub.V1.ModifyAckDeadlineRequest{
-              subscription: subscription_path,
-              ack_ids: ack_ids,
-              ack_deadline_seconds: ack_deadline_seconds
-            }
-
-            Google.Pubsub.V1.Subscriber.Stub.modify_ack_deadline(channel, request, grpc_opts)
-          end
-          |> Client.execute()
-          |> Result.unwrap_empty()
-        end
+        do_modify_ack_deadline(project_id, subscription_id, ack_ids, ack_deadline_seconds, opts)
       end
     )
+  end
+
+  defp do_modify_ack_deadline(project_id, subscription_id, ack_ids, ack_deadline_seconds, opts) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_subscription_id(subscription_id),
+         {:ok, _} <- Validation.validate_ack_ids(ack_ids),
+         {:ok, _} <- Validation.validate_ack_deadline_with_zero(ack_deadline_seconds),
+         {:ok, grpc_opts} <- grpc_opts(opts) do
+      subscription_path = subscription_path(project_id, subscription_id)
+
+      fn channel ->
+        request = %Google.Pubsub.V1.ModifyAckDeadlineRequest{
+          subscription: subscription_path,
+          ack_ids: ack_ids,
+          ack_deadline_seconds: ack_deadline_seconds
+        }
+
+        Google.Pubsub.V1.Subscriber.Stub.modify_ack_deadline(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap_empty()
+    end
   end
 
   @doc """

--- a/lib/pubsub_grpc/application.ex
+++ b/lib/pubsub_grpc/application.ex
@@ -128,47 +128,7 @@ defmodule PubsubGrpc.Application do
   # Support legacy configuration format
   defp build_legacy_config do
     pool_size = Application.get_env(:pubsub_grpc, :default_pool_size, 5)
-    emulator_config = Application.get_env(:pubsub_grpc, :emulator)
-
-    config_opts =
-      case emulator_config do
-        nil ->
-          # Production Google Cloud Pub/Sub
-          [
-            endpoint: [
-              type: :production,
-              host: "pubsub.googleapis.com",
-              port: 443,
-              ssl: production_ssl_opts()
-            ],
-            pool: [size: pool_size, name: PubsubGrpc.ConnectionPool]
-          ]
-
-        emulator_opts when is_list(emulator_opts) ->
-          # Local emulator
-          [
-            endpoint: [
-              type: :local,
-              host: emulator_opts[:host] || "localhost",
-              port: emulator_opts[:port] || 8085
-            ],
-            pool: [size: pool_size, name: PubsubGrpc.ConnectionPool],
-            # Disable pinging for emulator
-            connection: [ping_interval: nil, health_check: true]
-          ]
-
-        _ ->
-          # Default production
-          [
-            endpoint: [
-              type: :production,
-              host: "pubsub.googleapis.com",
-              port: 443,
-              ssl: production_ssl_opts()
-            ],
-            pool: [size: pool_size, name: PubsubGrpc.ConnectionPool]
-          ]
-      end
+    config_opts = legacy_config_opts(Application.get_env(:pubsub_grpc, :emulator), pool_size)
 
     case GrpcConnectionPool.Config.new(config_opts) do
       {:ok, config} ->
@@ -177,21 +137,49 @@ defmodule PubsubGrpc.Application do
 
       {:error, reason} ->
         Logger.error("PubsubGrpc: legacy config failed: #{inspect(reason)}")
+        production_default_config!(pool_size, reason)
+    end
+  end
 
-        case GrpcConnectionPool.Config.production(
-               host: "pubsub.googleapis.com",
-               port: 443,
-               pool_name: PubsubGrpc.ConnectionPool,
-               pool_size: pool_size
-             ) do
-          {:ok, config} ->
-            Logger.warning("PubsubGrpc: using production defaults after legacy config failure")
-            config
+  defp legacy_config_opts(emulator_opts, pool_size) when is_list(emulator_opts) do
+    [
+      endpoint: [
+        type: :local,
+        host: emulator_opts[:host] || "localhost",
+        port: emulator_opts[:port] || 8085
+      ],
+      pool: [size: pool_size, name: PubsubGrpc.ConnectionPool],
+      # Disable pinging for emulator
+      connection: [ping_interval: nil, health_check: true]
+    ]
+  end
 
-          {:error, fallback_reason} ->
-            raise "PubsubGrpc: unable to build connection pool config " <>
-                    "(legacy: #{inspect(reason)}, production default: #{inspect(fallback_reason)})"
-        end
+  defp legacy_config_opts(_emulator_opts, pool_size) do
+    [
+      endpoint: [
+        type: :production,
+        host: "pubsub.googleapis.com",
+        port: 443,
+        ssl: production_ssl_opts()
+      ],
+      pool: [size: pool_size, name: PubsubGrpc.ConnectionPool]
+    ]
+  end
+
+  defp production_default_config!(pool_size, reason) do
+    case GrpcConnectionPool.Config.production(
+           host: "pubsub.googleapis.com",
+           port: 443,
+           pool_name: PubsubGrpc.ConnectionPool,
+           pool_size: pool_size
+         ) do
+      {:ok, config} ->
+        Logger.warning("PubsubGrpc: using production defaults after legacy config failure")
+        config
+
+      {:error, fallback_reason} ->
+        raise "PubsubGrpc: unable to build connection pool config " <>
+                "(legacy: #{inspect(reason)}, production default: #{inspect(fallback_reason)})"
     end
   end
 

--- a/lib/pubsub_grpc/application.ex
+++ b/lib/pubsub_grpc/application.ex
@@ -85,16 +85,26 @@ defmodule PubsubGrpc.Application do
 
   @impl true
   def start(_type, _args) do
-    PubsubGrpc.Auth.init_cache()
+    warn_if_emulator_mode()
     config = build_connection_pool_config()
 
     children = [
+      PubsubGrpc.Auth.Cache,
       {GRPC.Client.Supervisor, []},
       {GrpcConnectionPool, config}
     ]
 
     opts = [strategy: :one_for_one, name: PubsubGrpc.Supervisor, max_restarts: 10]
     Supervisor.start_link(children, opts)
+  end
+
+  defp warn_if_emulator_mode do
+    if Application.get_env(:pubsub_grpc, :emulator) do
+      Logger.warning(
+        "PubsubGrpc: emulator mode is active — authentication will be skipped. " <>
+          "Remove `config :pubsub_grpc, :emulator, _` for production."
+      )
+    end
   end
 
   # Private functions
@@ -129,7 +139,7 @@ defmodule PubsubGrpc.Application do
               type: :production,
               host: "pubsub.googleapis.com",
               port: 443,
-              ssl: []
+              ssl: production_ssl_opts()
             ],
             pool: [size: pool_size, name: PubsubGrpc.ConnectionPool]
           ]
@@ -154,7 +164,7 @@ defmodule PubsubGrpc.Application do
               type: :production,
               host: "pubsub.googleapis.com",
               port: 443,
-              ssl: []
+              ssl: production_ssl_opts()
             ],
             pool: [size: pool_size, name: PubsubGrpc.ConnectionPool]
           ]
@@ -166,19 +176,33 @@ defmodule PubsubGrpc.Application do
         config
 
       {:error, reason} ->
-        Logger.warning(
-          "PubsubGrpc: legacy config failed (#{inspect(reason)}), falling back to production defaults"
-        )
+        Logger.error("PubsubGrpc: legacy config failed: #{inspect(reason)}")
 
-        {:ok, config} =
-          GrpcConnectionPool.Config.production(
-            host: "pubsub.googleapis.com",
-            port: 443,
-            pool_name: PubsubGrpc.ConnectionPool,
-            pool_size: pool_size
-          )
+        case GrpcConnectionPool.Config.production(
+               host: "pubsub.googleapis.com",
+               port: 443,
+               pool_name: PubsubGrpc.ConnectionPool,
+               pool_size: pool_size
+             ) do
+          {:ok, config} ->
+            Logger.warning("PubsubGrpc: using production defaults after legacy config failure")
+            config
 
-        config
+          {:error, fallback_reason} ->
+            raise "PubsubGrpc: unable to build connection pool config " <>
+                    "(legacy: #{inspect(reason)}, production default: #{inspect(fallback_reason)})"
+        end
     end
+  end
+
+  # Strict TLS for the production endpoint: verify the server certificate against
+  # the OS trust store. Override via `config :pubsub_grpc, :ssl_opts, [...]`.
+  defp production_ssl_opts do
+    Application.get_env(
+      :pubsub_grpc,
+      :ssl_opts,
+      verify: :verify_peer,
+      cacerts: :public_key.cacerts_get()
+    )
   end
 end

--- a/lib/pubsub_grpc/auth.ex
+++ b/lib/pubsub_grpc/auth.ex
@@ -109,70 +109,94 @@ defmodule PubsubGrpc.Auth do
   # Private functions
 
   defp get_cached_token do
-    with true <- :ets.whereis(@cache_table) != :undefined,
-         [{@cache_key, token, expires_at}] <- :ets.lookup(@cache_table, @cache_key),
-         true <- System.monotonic_time(:millisecond) < expires_at do
-      {:ok, token}
-    else
-      _ -> :miss
+    case :ets.lookup(@cache_table, @cache_key) do
+      [{@cache_key, token, expires_at}] ->
+        if System.monotonic_time(:millisecond) < expires_at, do: {:ok, token}, else: :miss
+
+      [] ->
+        :miss
     end
+  rescue
+    # Table doesn't exist (Cache GenServer not started yet, or torn down).
+    ArgumentError -> :miss
   end
 
   defp cache_token(token, ttl_ms) do
-    if :ets.whereis(@cache_table) != :undefined do
-      expires_at = System.monotonic_time(:millisecond) + ttl_ms
-      :ets.insert(@cache_table, {@cache_key, token, expires_at})
-    end
-
+    expires_at = System.monotonic_time(:millisecond) + ttl_ms
+    :ets.insert(@cache_table, {@cache_key, token, expires_at})
     :ok
+  rescue
+    ArgumentError -> :ok
   end
 
   defp fetch_and_cache_token do
-    case Application.get_env(:pubsub_grpc, :goth) do
-      nil ->
-        get_token_fallback()
+    {source, fun} =
+      case Application.get_env(:pubsub_grpc, :goth) do
+        nil -> {:gcloud, fn -> get_token_fallback() end}
+        goth_name -> {:goth, fn -> get_token_from_goth(goth_name) end}
+      end
 
-      goth_name ->
-        get_token_from_goth(goth_name)
-    end
+    :telemetry.span([:pubsub_grpc, :auth], %{source: source}, fn ->
+      result = fun.()
+      {result, %{source: source, result: classify(result)}}
+    end)
   end
+
+  defp classify({:ok, _}), do: :ok
+  defp classify({:error, _}), do: :error
 
   defp get_token_from_goth(goth_name) do
     if Code.ensure_loaded?(Goth) do
       goth_name |> Goth.fetch() |> handle_goth_result()
     else
-      get_token_fallback()
+      Logger.error("PubsubGrpc: :goth configured but Goth module not loaded")
+
+      {:error,
+       Error.new(
+         :unauthenticated,
+         "Goth configured but not loaded; add :goth to your deps or remove :pubsub_grpc :goth config"
+       )}
     end
+  rescue
+    e ->
+      Logger.error("PubsubGrpc: Goth.fetch raised: #{inspect(e.__struct__)}")
+      {:error, Error.new(:unauthenticated, "Goth authentication crashed", e)}
+  catch
+    kind, reason ->
+      Logger.error("PubsubGrpc: Goth.fetch exited: #{kind}")
+      {:error, Error.new(:unauthenticated, "Goth authentication crashed", {kind, reason})}
   end
 
-  defp handle_goth_result({:ok, %{token: token, type: type, expires: expires}}) do
+  defp handle_goth_result({:ok, %{token: token, type: type} = result})
+       when is_binary(token) and is_binary(type) do
     bearer = "#{type} #{token}"
-    expires_dt = if is_integer(expires), do: DateTime.from_unix!(expires), else: expires
-    ttl_ms = max(DateTime.diff(expires_dt, DateTime.utc_now(), :millisecond) - 60_000, 0)
-    cache_token(bearer, ttl_ms)
-    {:ok, bearer}
-  end
-
-  defp handle_goth_result({:ok, %{token: token, type: type}}) do
-    bearer = "#{type} #{token}"
-    cache_token(bearer, @cli_token_ttl_ms)
+    cache_token(bearer, goth_ttl_ms(result))
     {:ok, bearer}
   end
 
   defp handle_goth_result({:error, reason}) do
-    Logger.warning(
-      "PubsubGrpc: Goth.fetch failed (#{inspect(reason)}), falling back to gcloud CLI"
-    )
+    # Goth was explicitly configured — do not silently fall back to gcloud CLI;
+    # surface the original error so the caller knows their chosen auth path failed.
+    Logger.warning("PubsubGrpc: Goth.fetch failed (#{error_tag(reason)})")
 
-    case get_token_fallback() do
-      {:ok, _} = ok ->
-        ok
+    {:error, Error.new(:unauthenticated, "Goth authentication failed", reason)}
+  end
 
-      {:error, _} ->
-        {:error,
-         Error.new(:unauthenticated, "auth failed: Goth error: #{inspect(reason)}", reason)}
+  defp goth_ttl_ms(%{expires: expires}) when not is_nil(expires) do
+    expires_dt =
+      cond do
+        is_integer(expires) -> DateTime.from_unix!(expires)
+        match?(%DateTime{}, expires) -> expires
+        true -> nil
+      end
+
+    case expires_dt do
+      nil -> @cli_token_ttl_ms
+      dt -> max(DateTime.diff(dt, DateTime.utc_now(), :millisecond) - 60_000, 0)
     end
   end
+
+  defp goth_ttl_ms(_), do: @cli_token_ttl_ms
 
   defp get_token_fallback do
     case System.cmd("gcloud", ["auth", "application-default", "print-access-token"],
@@ -184,22 +208,31 @@ defmodule PubsubGrpc.Auth do
         {:ok, token}
 
       {error_output, exit_code} ->
-        Logger.error(
-          "PubsubGrpc: gcloud CLI auth failed (exit #{exit_code}): #{String.trim(error_output)}"
-        )
+        # Log raw stderr at debug only (may contain ADC paths, account emails).
+        Logger.debug(fn -> "PubsubGrpc: gcloud stderr: #{String.trim(error_output)}" end)
+        Logger.error("PubsubGrpc: gcloud CLI auth failed (exit #{exit_code})")
 
         {:error,
-         Error.new(:unauthenticated, "gcloud CLI auth failed: #{String.trim(error_output)}")}
+         Error.new(
+           :unauthenticated,
+           "gcloud CLI auth failed (exit #{exit_code})",
+           {:gcloud_exit, exit_code}
+         )}
     end
   rescue
     e ->
-      Logger.error("PubsubGrpc: auth unavailable - #{Exception.message(e)}")
+      Logger.error("PubsubGrpc: auth unavailable: #{inspect(e.__struct__)}")
 
-      {:error,
-       Error.new(:unauthenticated, "no authentication available: #{Exception.message(e)}", e)}
+      {:error, Error.new(:unauthenticated, "no authentication available", e)}
   catch
     kind, reason ->
-      Logger.error("PubsubGrpc: auth unavailable - #{inspect({kind, reason})}")
+      Logger.error("PubsubGrpc: auth unavailable: #{kind}")
       {:error, Error.new(:unauthenticated, "no authentication available", {kind, reason})}
   end
+
+  # Best-effort tag for logging: an atom describing the error shape, never its contents.
+  defp error_tag(%{__struct__: mod}), do: mod
+  defp error_tag(reason) when is_atom(reason), do: reason
+  defp error_tag({tag, _}) when is_atom(tag), do: tag
+  defp error_tag(_), do: :unknown
 end

--- a/lib/pubsub_grpc/auth/cache.ex
+++ b/lib/pubsub_grpc/auth/cache.ex
@@ -1,0 +1,39 @@
+defmodule PubsubGrpc.Auth.Cache do
+  @moduledoc false
+  # Owns the :pubsub_grpc_auth_cache ETS table.
+  #
+  # Why a process: a public ETS table dies with its owner. Without a supervised
+  # owner, the table would be created by whatever caller first touched
+  # `PubsubGrpc.Auth` and would not be re-created after an Application restart.
+
+  use GenServer
+
+  @table :pubsub_grpc_auth_cache
+
+  @spec start_link(any()) :: GenServer.on_start()
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @spec table() :: :ets.tid() | atom()
+  def table, do: @table
+
+  @impl true
+  def init(:ok) do
+    case :ets.whereis(@table) do
+      :undefined ->
+        :ets.new(@table, [
+          :named_table,
+          :public,
+          :set,
+          read_concurrency: true
+        ])
+
+      _tid ->
+        # Already exists (test re-init or hot upgrade) — leave it alone.
+        :ok
+    end
+
+    {:ok, nil}
+  end
+end

--- a/lib/pubsub_grpc/error.ex
+++ b/lib/pubsub_grpc/error.ex
@@ -31,6 +31,7 @@ defmodule PubsubGrpc.Error do
           grpc_status: non_neg_integer() | nil
         }
 
+  @derive {Inspect, only: [:code, :message, :grpc_status]}
   defstruct [:code, :message, :details, :grpc_status]
 
   @grpc_status_codes %{

--- a/lib/pubsub_grpc/result.ex
+++ b/lib/pubsub_grpc/result.ex
@@ -1,0 +1,39 @@
+defmodule PubsubGrpc.Result do
+  @moduledoc false
+  # Shared helpers for normalizing gRPC client return values into
+  # `{:ok, _} | {:error, %PubsubGrpc.Error{}}`. Used by `PubsubGrpc` and
+  # `PubsubGrpc.Schema` so error mapping stays consistent.
+
+  alias PubsubGrpc.Error
+
+  @type client_result :: {:ok, {:ok, term()} | {:error, term()}} | {:error, term()}
+
+  @spec unwrap(client_result()) :: {:ok, term()} | {:error, Error.t()}
+  def unwrap({:ok, {:ok, result}}), do: {:ok, result}
+  def unwrap(other), do: unwrap_error(other)
+
+  @spec unwrap_empty(client_result()) :: :ok | {:error, Error.t()}
+  def unwrap_empty({:ok, {:ok, %Google.Protobuf.Empty{}}}), do: :ok
+  def unwrap_empty(other), do: unwrap_error(other)
+
+  @spec unwrap_list(client_result(), atom(), atom()) ::
+          {:ok, map()} | {:error, Error.t()}
+  def unwrap_list({:ok, {:ok, response}}, items_key, token_key) do
+    {:ok, %{items_key => Map.get(response, items_key), token_key => Map.get(response, token_key)}}
+  end
+
+  def unwrap_list(other, _items_key, _token_key), do: unwrap_error(other)
+
+  @spec unwrap_error(client_result()) :: {:error, Error.t()}
+  def unwrap_error({:ok, {:error, %GRPC.RPCError{} = error}}) do
+    {:error, Error.from_grpc_error(error)}
+  end
+
+  def unwrap_error({:ok, {:error, error}}) do
+    {:error, Error.new(:internal, "unexpected gRPC error", error)}
+  end
+
+  def unwrap_error({:error, reason}) do
+    {:error, Error.new(:connection_error, "connection error", reason)}
+  end
+end

--- a/lib/pubsub_grpc/schema.ex
+++ b/lib/pubsub_grpc/schema.ex
@@ -7,152 +7,172 @@ defmodule PubsubGrpc.Schema do
   """
 
   alias Google.Pubsub.V1, as: PubsubV1
-  alias PubsubGrpc.{Client, Error, Validation}
+  alias PubsubGrpc.{Client, Error, Result, Telemetry, Validation}
   alias PubsubV1.SchemaService.Stub, as: SchemaStub
 
   @spec list_schemas(String.t(), keyword()) ::
           {:ok, %{schemas: list(), next_page_token: String.t()}} | {:error, Error.t()}
   def list_schemas(project_id, opts \\ []) do
-    view = opts[:view] || :basic
+    Telemetry.span(:list_schemas, %{project_id: project_id}, fn ->
+      view = opts[:view] || :basic
 
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, view_enum} <- Validation.validate_schema_view(view),
-         {:ok, grpc_opts} <- grpc_opts() do
-      project_path = "projects/#{project_id}"
+      with {:ok, _} <- Validation.validate_project_id(project_id),
+           {:ok, view_enum} <- Validation.validate_schema_view(view),
+           {:ok, grpc_opts} <- grpc_opts(opts) do
+        project_path = "projects/#{project_id}"
 
-      fn channel ->
-        request = %PubsubV1.ListSchemasRequest{
-          parent: project_path,
-          view: view_enum,
-          page_size: Keyword.get(opts, :page_size, 0),
-          page_token: Keyword.get(opts, :page_token, "")
-        }
+        fn channel ->
+          request = %PubsubV1.ListSchemasRequest{
+            parent: project_path,
+            view: view_enum,
+            page_size: Keyword.get(opts, :page_size, 0),
+            page_token: Keyword.get(opts, :page_token, "")
+          }
 
-        SchemaStub.list_schemas(channel, request, grpc_opts)
+          SchemaStub.list_schemas(channel, request, grpc_opts)
+        end
+        |> Client.execute()
+        |> Result.unwrap_list(:schemas, :next_page_token)
       end
-      |> Client.execute()
-      |> unwrap_list_result(:schemas, :next_page_token)
-    end
+    end)
   end
 
   @spec get_schema(String.t(), String.t(), keyword()) ::
           {:ok, PubsubV1.Schema.t()} | {:error, Error.t()}
   def get_schema(project_id, schema_id, opts \\ []) do
-    view = opts[:view] || :full
+    Telemetry.span(:get_schema, %{project_id: project_id, schema_id: schema_id}, fn ->
+      view = opts[:view] || :full
 
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_schema_id(schema_id),
-         {:ok, view_enum} <- Validation.validate_schema_view(view),
-         {:ok, grpc_opts} <- grpc_opts() do
-      schema_path = schema_path(project_id, schema_id)
+      with {:ok, _} <- Validation.validate_project_id(project_id),
+           {:ok, _} <- Validation.validate_schema_id(schema_id),
+           {:ok, view_enum} <- Validation.validate_schema_view(view),
+           {:ok, grpc_opts} <- grpc_opts(opts) do
+        schema_path = schema_path(project_id, schema_id)
 
-      fn channel ->
-        request = %PubsubV1.GetSchemaRequest{
-          name: schema_path,
-          view: view_enum
-        }
+        fn channel ->
+          request = %PubsubV1.GetSchemaRequest{
+            name: schema_path,
+            view: view_enum
+          }
 
-        SchemaStub.get_schema(channel, request, grpc_opts)
+          SchemaStub.get_schema(channel, request, grpc_opts)
+        end
+        |> Client.execute()
+        |> Result.unwrap()
       end
-      |> Client.execute()
-      |> unwrap_result()
-    end
+    end)
   end
 
   @spec create_schema(String.t(), String.t(), :protocol_buffer | :avro, String.t()) ::
           {:ok, PubsubV1.Schema.t()} | {:error, Error.t()}
   def create_schema(project_id, schema_id, type, definition) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_schema_id(schema_id),
-         {:ok, type_enum} <- Validation.validate_schema_type(type),
-         {:ok, grpc_opts} <- grpc_opts() do
-      project_path = "projects/#{project_id}"
+    Telemetry.span(
+      :create_schema,
+      %{project_id: project_id, schema_id: schema_id, schema_type: type},
+      fn ->
+        with {:ok, _} <- Validation.validate_project_id(project_id),
+             {:ok, _} <- Validation.validate_schema_id(schema_id),
+             {:ok, type_enum} <- Validation.validate_schema_type(type),
+             {:ok, grpc_opts} <- grpc_opts() do
+          project_path = "projects/#{project_id}"
 
-      fn channel ->
-        schema = %PubsubV1.Schema{
-          type: type_enum,
-          definition: definition
-        }
+          fn channel ->
+            schema = %PubsubV1.Schema{
+              type: type_enum,
+              definition: definition
+            }
 
-        request = %PubsubV1.CreateSchemaRequest{
-          parent: project_path,
-          schema_id: schema_id,
-          schema: schema
-        }
+            request = %PubsubV1.CreateSchemaRequest{
+              parent: project_path,
+              schema_id: schema_id,
+              schema: schema
+            }
 
-        SchemaStub.create_schema(channel, request, grpc_opts)
+            SchemaStub.create_schema(channel, request, grpc_opts)
+          end
+          |> Client.execute()
+          |> Result.unwrap()
+        end
       end
-      |> Client.execute()
-      |> unwrap_result()
-    end
+    )
   end
 
   @spec delete_schema(String.t(), String.t()) :: :ok | {:error, Error.t()}
   def delete_schema(project_id, schema_id) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_schema_id(schema_id),
-         {:ok, grpc_opts} <- grpc_opts() do
-      schema_path = schema_path(project_id, schema_id)
+    Telemetry.span(:delete_schema, %{project_id: project_id, schema_id: schema_id}, fn ->
+      with {:ok, _} <- Validation.validate_project_id(project_id),
+           {:ok, _} <- Validation.validate_schema_id(schema_id),
+           {:ok, grpc_opts} <- grpc_opts() do
+        schema_path = schema_path(project_id, schema_id)
 
-      fn channel ->
-        request = %PubsubV1.DeleteSchemaRequest{name: schema_path}
-        SchemaStub.delete_schema(channel, request, grpc_opts)
+        fn channel ->
+          request = %PubsubV1.DeleteSchemaRequest{name: schema_path}
+          SchemaStub.delete_schema(channel, request, grpc_opts)
+        end
+        |> Client.execute()
+        |> Result.unwrap_empty()
       end
-      |> Client.execute()
-      |> unwrap_empty_result()
-    end
+    end)
   end
 
   @spec validate_schema(String.t(), :protocol_buffer | :avro, String.t()) ::
           {:ok, PubsubV1.ValidateSchemaResponse.t()} | {:error, Error.t()}
   def validate_schema(project_id, type, definition) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, type_enum} <- Validation.validate_schema_type(type),
-         {:ok, grpc_opts} <- grpc_opts() do
-      project_path = "projects/#{project_id}"
+    Telemetry.span(:validate_schema, %{project_id: project_id, schema_type: type}, fn ->
+      with {:ok, _} <- Validation.validate_project_id(project_id),
+           {:ok, type_enum} <- Validation.validate_schema_type(type),
+           {:ok, grpc_opts} <- grpc_opts() do
+        project_path = "projects/#{project_id}"
 
-      fn channel ->
-        schema = %PubsubV1.Schema{
-          type: type_enum,
-          definition: definition
-        }
+        fn channel ->
+          schema = %PubsubV1.Schema{
+            type: type_enum,
+            definition: definition
+          }
 
-        request = %PubsubV1.ValidateSchemaRequest{
-          parent: project_path,
-          schema: schema
-        }
+          request = %PubsubV1.ValidateSchemaRequest{
+            parent: project_path,
+            schema: schema
+          }
 
-        SchemaStub.validate_schema(channel, request, grpc_opts)
+          SchemaStub.validate_schema(channel, request, grpc_opts)
+        end
+        |> Client.execute()
+        |> Result.unwrap()
       end
-      |> Client.execute()
-      |> unwrap_result()
-    end
+    end)
   end
 
   @spec list_schema_revisions(String.t(), String.t(), keyword()) ::
           {:ok, %{schemas: list(), next_page_token: String.t()}} | {:error, Error.t()}
   def list_schema_revisions(project_id, schema_id, opts \\ []) do
-    view = opts[:view] || :basic
+    Telemetry.span(
+      :list_schema_revisions,
+      %{project_id: project_id, schema_id: schema_id},
+      fn ->
+        view = opts[:view] || :basic
 
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, _} <- Validation.validate_schema_id(schema_id),
-         {:ok, view_enum} <- Validation.validate_schema_view(view),
-         {:ok, grpc_opts} <- grpc_opts() do
-      schema_path = schema_path(project_id, schema_id)
+        with {:ok, _} <- Validation.validate_project_id(project_id),
+             {:ok, _} <- Validation.validate_schema_id(schema_id),
+             {:ok, view_enum} <- Validation.validate_schema_view(view),
+             {:ok, grpc_opts} <- grpc_opts(opts) do
+          schema_path = schema_path(project_id, schema_id)
 
-      fn channel ->
-        request = %PubsubV1.ListSchemaRevisionsRequest{
-          name: schema_path,
-          view: view_enum,
-          page_size: Keyword.get(opts, :page_size, 0),
-          page_token: Keyword.get(opts, :page_token, "")
-        }
+          fn channel ->
+            request = %PubsubV1.ListSchemaRevisionsRequest{
+              name: schema_path,
+              view: view_enum,
+              page_size: Keyword.get(opts, :page_size, 0),
+              page_token: Keyword.get(opts, :page_token, "")
+            }
 
-        SchemaStub.list_schema_revisions(channel, request, grpc_opts)
+            SchemaStub.list_schema_revisions(channel, request, grpc_opts)
+          end
+          |> Client.execute()
+          |> Result.unwrap_list(:schemas, :next_page_token)
+        end
       end
-      |> Client.execute()
-      |> unwrap_list_result(:schemas, :next_page_token)
-    end
+    )
   end
 
   @doc """
@@ -167,32 +187,38 @@ defmodule PubsubGrpc.Schema do
   @spec validate_message(String.t(), String.t(), binary(), :json | :binary) ::
           {:ok, PubsubV1.ValidateMessageResponse.t()} | {:error, Error.t()}
   def validate_message(project_id, schema_name, message, encoding) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, encoding_enum} <- Validation.validate_encoding(encoding),
-         {:ok, grpc_opts} <- grpc_opts() do
-      project_path = "projects/#{project_id}"
+    Telemetry.span(
+      :validate_message,
+      %{project_id: project_id, schema_name: schema_name, encoding: encoding},
+      fn ->
+        with {:ok, _} <- Validation.validate_project_id(project_id),
+             {:ok, encoding_enum} <- Validation.validate_encoding(encoding),
+             {:ok, grpc_opts} <- grpc_opts() do
+          project_path = "projects/#{project_id}"
 
-      # If schema_name doesn't contain a slash, treat it as a schema ID
-      name =
-        if String.contains?(schema_name, "/") do
-          schema_name
-        else
-          schema_path(project_id, schema_name)
+          # If schema_name doesn't contain a slash, treat it as a schema ID
+          name =
+            if String.contains?(schema_name, "/") do
+              schema_name
+            else
+              schema_path(project_id, schema_name)
+            end
+
+          fn channel ->
+            request = %PubsubV1.ValidateMessageRequest{
+              parent: project_path,
+              schema_spec: {:name, name},
+              message: message,
+              encoding: encoding_enum
+            }
+
+            SchemaStub.validate_message(channel, request, grpc_opts)
+          end
+          |> Client.execute()
+          |> Result.unwrap()
         end
-
-      fn channel ->
-        request = %PubsubV1.ValidateMessageRequest{
-          parent: project_path,
-          schema_spec: {:name, name},
-          message: message,
-          encoding: encoding_enum
-        }
-
-        SchemaStub.validate_message(channel, request, grpc_opts)
       end
-      |> Client.execute()
-      |> unwrap_result()
-    end
+    )
   end
 
   @doc """
@@ -214,68 +240,50 @@ defmodule PubsubGrpc.Schema do
         ) ::
           {:ok, PubsubV1.ValidateMessageResponse.t()} | {:error, Error.t()}
   def validate_message_with_schema(project_id, type, definition, message, encoding) do
-    with {:ok, _} <- Validation.validate_project_id(project_id),
-         {:ok, type_enum} <- Validation.validate_schema_type(type),
-         {:ok, encoding_enum} <- Validation.validate_encoding(encoding),
-         {:ok, grpc_opts} <- grpc_opts() do
-      project_path = "projects/#{project_id}"
+    Telemetry.span(
+      :validate_message_with_schema,
+      %{project_id: project_id, schema_type: type, encoding: encoding},
+      fn ->
+        with {:ok, _} <- Validation.validate_project_id(project_id),
+             {:ok, type_enum} <- Validation.validate_schema_type(type),
+             {:ok, encoding_enum} <- Validation.validate_encoding(encoding),
+             {:ok, grpc_opts} <- grpc_opts() do
+          project_path = "projects/#{project_id}"
 
-      fn channel ->
-        schema = %PubsubV1.Schema{
-          type: type_enum,
-          definition: definition
-        }
+          fn channel ->
+            schema = %PubsubV1.Schema{
+              type: type_enum,
+              definition: definition
+            }
 
-        request = %PubsubV1.ValidateMessageRequest{
-          parent: project_path,
-          schema_spec: {:schema, schema},
-          message: message,
-          encoding: encoding_enum
-        }
+            request = %PubsubV1.ValidateMessageRequest{
+              parent: project_path,
+              schema_spec: {:schema, schema},
+              message: message,
+              encoding: encoding_enum
+            }
 
-        SchemaStub.validate_message(channel, request, grpc_opts)
+            SchemaStub.validate_message(channel, request, grpc_opts)
+          end
+          |> Client.execute()
+          |> Result.unwrap()
+        end
       end
-      |> Client.execute()
-      |> unwrap_result()
-    end
+    )
   end
 
   # Private helpers
 
-  defp grpc_opts do
-    timeout = Application.get_env(:pubsub_grpc, :default_timeout, 30_000)
+  defp grpc_opts(opts \\ []) do
+    timeout = opts[:timeout] || Application.get_env(:pubsub_grpc, :default_timeout, 30_000)
 
     case PubsubGrpc.Auth.request_opts() do
-      {:ok, opts} -> {:ok, opts ++ [timeout: timeout]}
+      {:ok, auth_opts} -> {:ok, auth_opts ++ [timeout: timeout]}
       {:error, _} = error -> error
     end
   end
 
   defp schema_path(project_id, schema_id) do
     "projects/#{project_id}/schemas/#{schema_id}"
-  end
-
-  defp unwrap_result({:ok, {:ok, result}}), do: {:ok, result}
-  defp unwrap_result(other), do: unwrap_error(other)
-
-  defp unwrap_empty_result({:ok, {:ok, %Google.Protobuf.Empty{}}}), do: :ok
-  defp unwrap_empty_result(other), do: unwrap_error(other)
-
-  defp unwrap_list_result({:ok, {:ok, response}}, items_key, token_key) do
-    {:ok, %{items_key => Map.get(response, items_key), token_key => Map.get(response, token_key)}}
-  end
-
-  defp unwrap_list_result(other, _items_key, _token_key), do: unwrap_error(other)
-
-  defp unwrap_error({:ok, {:error, %GRPC.RPCError{} = error}}) do
-    {:error, Error.from_grpc_error(error)}
-  end
-
-  defp unwrap_error({:ok, {:error, error}}) do
-    {:error, Error.new(:internal, "unexpected error: #{inspect(error)}", error)}
-  end
-
-  defp unwrap_error({:error, reason}) do
-    {:error, Error.new(:connection_error, "connection error: #{inspect(reason)}", reason)}
   end
 end

--- a/lib/pubsub_grpc/schema.ex
+++ b/lib/pubsub_grpc/schema.ex
@@ -14,53 +14,61 @@ defmodule PubsubGrpc.Schema do
           {:ok, %{schemas: list(), next_page_token: String.t()}} | {:error, Error.t()}
   def list_schemas(project_id, opts \\ []) do
     Telemetry.span(:list_schemas, %{project_id: project_id}, fn ->
-      view = opts[:view] || :basic
-
-      with {:ok, _} <- Validation.validate_project_id(project_id),
-           {:ok, view_enum} <- Validation.validate_schema_view(view),
-           {:ok, grpc_opts} <- grpc_opts(opts) do
-        project_path = "projects/#{project_id}"
-
-        fn channel ->
-          request = %PubsubV1.ListSchemasRequest{
-            parent: project_path,
-            view: view_enum,
-            page_size: Keyword.get(opts, :page_size, 0),
-            page_token: Keyword.get(opts, :page_token, "")
-          }
-
-          SchemaStub.list_schemas(channel, request, grpc_opts)
-        end
-        |> Client.execute()
-        |> Result.unwrap_list(:schemas, :next_page_token)
-      end
+      do_list_schemas(project_id, opts)
     end)
+  end
+
+  defp do_list_schemas(project_id, opts) do
+    view = opts[:view] || :basic
+
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, view_enum} <- Validation.validate_schema_view(view),
+         {:ok, grpc_opts} <- grpc_opts(opts) do
+      project_path = "projects/#{project_id}"
+
+      fn channel ->
+        request = %PubsubV1.ListSchemasRequest{
+          parent: project_path,
+          view: view_enum,
+          page_size: Keyword.get(opts, :page_size, 0),
+          page_token: Keyword.get(opts, :page_token, "")
+        }
+
+        SchemaStub.list_schemas(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap_list(:schemas, :next_page_token)
+    end
   end
 
   @spec get_schema(String.t(), String.t(), keyword()) ::
           {:ok, PubsubV1.Schema.t()} | {:error, Error.t()}
   def get_schema(project_id, schema_id, opts \\ []) do
     Telemetry.span(:get_schema, %{project_id: project_id, schema_id: schema_id}, fn ->
-      view = opts[:view] || :full
-
-      with {:ok, _} <- Validation.validate_project_id(project_id),
-           {:ok, _} <- Validation.validate_schema_id(schema_id),
-           {:ok, view_enum} <- Validation.validate_schema_view(view),
-           {:ok, grpc_opts} <- grpc_opts(opts) do
-        schema_path = schema_path(project_id, schema_id)
-
-        fn channel ->
-          request = %PubsubV1.GetSchemaRequest{
-            name: schema_path,
-            view: view_enum
-          }
-
-          SchemaStub.get_schema(channel, request, grpc_opts)
-        end
-        |> Client.execute()
-        |> Result.unwrap()
-      end
+      do_get_schema(project_id, schema_id, opts)
     end)
+  end
+
+  defp do_get_schema(project_id, schema_id, opts) do
+    view = opts[:view] || :full
+
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_schema_id(schema_id),
+         {:ok, view_enum} <- Validation.validate_schema_view(view),
+         {:ok, grpc_opts} <- grpc_opts(opts) do
+      schema_path = schema_path(project_id, schema_id)
+
+      fn channel ->
+        request = %PubsubV1.GetSchemaRequest{
+          name: schema_path,
+          view: view_enum
+        }
+
+        SchemaStub.get_schema(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap()
+    end
   end
 
   @spec create_schema(String.t(), String.t(), :protocol_buffer | :avro, String.t()) ::
@@ -69,78 +77,88 @@ defmodule PubsubGrpc.Schema do
     Telemetry.span(
       :create_schema,
       %{project_id: project_id, schema_id: schema_id, schema_type: type},
-      fn ->
-        with {:ok, _} <- Validation.validate_project_id(project_id),
-             {:ok, _} <- Validation.validate_schema_id(schema_id),
-             {:ok, type_enum} <- Validation.validate_schema_type(type),
-             {:ok, grpc_opts} <- grpc_opts() do
-          project_path = "projects/#{project_id}"
-
-          fn channel ->
-            schema = %PubsubV1.Schema{
-              type: type_enum,
-              definition: definition
-            }
-
-            request = %PubsubV1.CreateSchemaRequest{
-              parent: project_path,
-              schema_id: schema_id,
-              schema: schema
-            }
-
-            SchemaStub.create_schema(channel, request, grpc_opts)
-          end
-          |> Client.execute()
-          |> Result.unwrap()
-        end
-      end
+      fn -> do_create_schema(project_id, schema_id, type, definition) end
     )
+  end
+
+  defp do_create_schema(project_id, schema_id, type, definition) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_schema_id(schema_id),
+         {:ok, type_enum} <- Validation.validate_schema_type(type),
+         {:ok, grpc_opts} <- grpc_opts() do
+      project_path = "projects/#{project_id}"
+
+      fn channel ->
+        schema = %PubsubV1.Schema{
+          type: type_enum,
+          definition: definition
+        }
+
+        request = %PubsubV1.CreateSchemaRequest{
+          parent: project_path,
+          schema_id: schema_id,
+          schema: schema
+        }
+
+        SchemaStub.create_schema(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap()
+    end
   end
 
   @spec delete_schema(String.t(), String.t()) :: :ok | {:error, Error.t()}
   def delete_schema(project_id, schema_id) do
     Telemetry.span(:delete_schema, %{project_id: project_id, schema_id: schema_id}, fn ->
-      with {:ok, _} <- Validation.validate_project_id(project_id),
-           {:ok, _} <- Validation.validate_schema_id(schema_id),
-           {:ok, grpc_opts} <- grpc_opts() do
-        schema_path = schema_path(project_id, schema_id)
-
-        fn channel ->
-          request = %PubsubV1.DeleteSchemaRequest{name: schema_path}
-          SchemaStub.delete_schema(channel, request, grpc_opts)
-        end
-        |> Client.execute()
-        |> Result.unwrap_empty()
-      end
+      do_delete_schema(project_id, schema_id)
     end)
+  end
+
+  defp do_delete_schema(project_id, schema_id) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_schema_id(schema_id),
+         {:ok, grpc_opts} <- grpc_opts() do
+      schema_path = schema_path(project_id, schema_id)
+
+      fn channel ->
+        request = %PubsubV1.DeleteSchemaRequest{name: schema_path}
+        SchemaStub.delete_schema(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap_empty()
+    end
   end
 
   @spec validate_schema(String.t(), :protocol_buffer | :avro, String.t()) ::
           {:ok, PubsubV1.ValidateSchemaResponse.t()} | {:error, Error.t()}
   def validate_schema(project_id, type, definition) do
     Telemetry.span(:validate_schema, %{project_id: project_id, schema_type: type}, fn ->
-      with {:ok, _} <- Validation.validate_project_id(project_id),
-           {:ok, type_enum} <- Validation.validate_schema_type(type),
-           {:ok, grpc_opts} <- grpc_opts() do
-        project_path = "projects/#{project_id}"
-
-        fn channel ->
-          schema = %PubsubV1.Schema{
-            type: type_enum,
-            definition: definition
-          }
-
-          request = %PubsubV1.ValidateSchemaRequest{
-            parent: project_path,
-            schema: schema
-          }
-
-          SchemaStub.validate_schema(channel, request, grpc_opts)
-        end
-        |> Client.execute()
-        |> Result.unwrap()
-      end
+      do_validate_schema(project_id, type, definition)
     end)
+  end
+
+  defp do_validate_schema(project_id, type, definition) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, type_enum} <- Validation.validate_schema_type(type),
+         {:ok, grpc_opts} <- grpc_opts() do
+      project_path = "projects/#{project_id}"
+
+      fn channel ->
+        schema = %PubsubV1.Schema{
+          type: type_enum,
+          definition: definition
+        }
+
+        request = %PubsubV1.ValidateSchemaRequest{
+          parent: project_path,
+          schema: schema
+        }
+
+        SchemaStub.validate_schema(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap()
+    end
   end
 
   @spec list_schema_revisions(String.t(), String.t(), keyword()) ::
@@ -149,30 +167,32 @@ defmodule PubsubGrpc.Schema do
     Telemetry.span(
       :list_schema_revisions,
       %{project_id: project_id, schema_id: schema_id},
-      fn ->
-        view = opts[:view] || :basic
-
-        with {:ok, _} <- Validation.validate_project_id(project_id),
-             {:ok, _} <- Validation.validate_schema_id(schema_id),
-             {:ok, view_enum} <- Validation.validate_schema_view(view),
-             {:ok, grpc_opts} <- grpc_opts(opts) do
-          schema_path = schema_path(project_id, schema_id)
-
-          fn channel ->
-            request = %PubsubV1.ListSchemaRevisionsRequest{
-              name: schema_path,
-              view: view_enum,
-              page_size: Keyword.get(opts, :page_size, 0),
-              page_token: Keyword.get(opts, :page_token, "")
-            }
-
-            SchemaStub.list_schema_revisions(channel, request, grpc_opts)
-          end
-          |> Client.execute()
-          |> Result.unwrap_list(:schemas, :next_page_token)
-        end
-      end
+      fn -> do_list_schema_revisions(project_id, schema_id, opts) end
     )
+  end
+
+  defp do_list_schema_revisions(project_id, schema_id, opts) do
+    view = opts[:view] || :basic
+
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, _} <- Validation.validate_schema_id(schema_id),
+         {:ok, view_enum} <- Validation.validate_schema_view(view),
+         {:ok, grpc_opts} <- grpc_opts(opts) do
+      schema_path = schema_path(project_id, schema_id)
+
+      fn channel ->
+        request = %PubsubV1.ListSchemaRevisionsRequest{
+          name: schema_path,
+          view: view_enum,
+          page_size: Keyword.get(opts, :page_size, 0),
+          page_token: Keyword.get(opts, :page_token, "")
+        }
+
+        SchemaStub.list_schema_revisions(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap_list(:schemas, :next_page_token)
+    end
   end
 
   @doc """
@@ -190,35 +210,37 @@ defmodule PubsubGrpc.Schema do
     Telemetry.span(
       :validate_message,
       %{project_id: project_id, schema_name: schema_name, encoding: encoding},
-      fn ->
-        with {:ok, _} <- Validation.validate_project_id(project_id),
-             {:ok, encoding_enum} <- Validation.validate_encoding(encoding),
-             {:ok, grpc_opts} <- grpc_opts() do
-          project_path = "projects/#{project_id}"
-
-          # If schema_name doesn't contain a slash, treat it as a schema ID
-          name =
-            if String.contains?(schema_name, "/") do
-              schema_name
-            else
-              schema_path(project_id, schema_name)
-            end
-
-          fn channel ->
-            request = %PubsubV1.ValidateMessageRequest{
-              parent: project_path,
-              schema_spec: {:name, name},
-              message: message,
-              encoding: encoding_enum
-            }
-
-            SchemaStub.validate_message(channel, request, grpc_opts)
-          end
-          |> Client.execute()
-          |> Result.unwrap()
-        end
-      end
+      fn -> do_validate_message(project_id, schema_name, message, encoding) end
     )
+  end
+
+  defp do_validate_message(project_id, schema_name, message, encoding) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, encoding_enum} <- Validation.validate_encoding(encoding),
+         {:ok, grpc_opts} <- grpc_opts() do
+      project_path = "projects/#{project_id}"
+
+      # If schema_name doesn't contain a slash, treat it as a schema ID
+      name =
+        if String.contains?(schema_name, "/") do
+          schema_name
+        else
+          schema_path(project_id, schema_name)
+        end
+
+      fn channel ->
+        request = %PubsubV1.ValidateMessageRequest{
+          parent: project_path,
+          schema_spec: {:name, name},
+          message: message,
+          encoding: encoding_enum
+        }
+
+        SchemaStub.validate_message(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap()
+    end
   end
 
   @doc """
@@ -243,33 +265,35 @@ defmodule PubsubGrpc.Schema do
     Telemetry.span(
       :validate_message_with_schema,
       %{project_id: project_id, schema_type: type, encoding: encoding},
-      fn ->
-        with {:ok, _} <- Validation.validate_project_id(project_id),
-             {:ok, type_enum} <- Validation.validate_schema_type(type),
-             {:ok, encoding_enum} <- Validation.validate_encoding(encoding),
-             {:ok, grpc_opts} <- grpc_opts() do
-          project_path = "projects/#{project_id}"
-
-          fn channel ->
-            schema = %PubsubV1.Schema{
-              type: type_enum,
-              definition: definition
-            }
-
-            request = %PubsubV1.ValidateMessageRequest{
-              parent: project_path,
-              schema_spec: {:schema, schema},
-              message: message,
-              encoding: encoding_enum
-            }
-
-            SchemaStub.validate_message(channel, request, grpc_opts)
-          end
-          |> Client.execute()
-          |> Result.unwrap()
-        end
-      end
+      fn -> do_validate_message_with_schema(project_id, type, definition, message, encoding) end
     )
+  end
+
+  defp do_validate_message_with_schema(project_id, type, definition, message, encoding) do
+    with {:ok, _} <- Validation.validate_project_id(project_id),
+         {:ok, type_enum} <- Validation.validate_schema_type(type),
+         {:ok, encoding_enum} <- Validation.validate_encoding(encoding),
+         {:ok, grpc_opts} <- grpc_opts() do
+      project_path = "projects/#{project_id}"
+
+      fn channel ->
+        schema = %PubsubV1.Schema{
+          type: type_enum,
+          definition: definition
+        }
+
+        request = %PubsubV1.ValidateMessageRequest{
+          parent: project_path,
+          schema_spec: {:schema, schema},
+          message: message,
+          encoding: encoding_enum
+        }
+
+        SchemaStub.validate_message(channel, request, grpc_opts)
+      end
+      |> Client.execute()
+      |> Result.unwrap()
+    end
   end
 
   # Private helpers

--- a/lib/pubsub_grpc/telemetry.ex
+++ b/lib/pubsub_grpc/telemetry.ex
@@ -1,0 +1,75 @@
+defmodule PubsubGrpc.Telemetry do
+  @moduledoc """
+  Telemetry events emitted by PubsubGrpc.
+
+  ## Events
+
+  All events share the prefix `[:pubsub_grpc, :request, _]` and are produced by
+  `:telemetry.span/3`. Three events are emitted per operation:
+
+    * `[:pubsub_grpc, :request, :start]` — measurements `%{system_time: integer, monotonic_time: integer}`
+    * `[:pubsub_grpc, :request, :stop]` — measurements `%{duration: integer, monotonic_time: integer}`
+    * `[:pubsub_grpc, :request, :exception]` — emitted when the wrapped function raises
+
+  ## Metadata
+
+  Start and stop events carry the operation context. Typical keys:
+
+    * `:operation` — atom, e.g. `:publish`, `:pull`, `:acknowledge`, `:create_topic`
+    * `:project_id` — Google Cloud project id (always present)
+    * `:topic_id`, `:subscription_id`, `:schema_id` — when applicable
+    * `:message_count` — for `:publish` and `:pull` (where known up front)
+
+  Stop events additionally include:
+
+    * `:result` — `:ok` for success, `{:error, error_code}` for known errors,
+      `:unknown` for unexpected return shapes
+
+  ## Example
+
+      :telemetry.attach(
+        "pubsub-grpc-logger",
+        [:pubsub_grpc, :request, :stop],
+        fn _event, %{duration: duration}, %{operation: op, result: result}, _config ->
+          IO.inspect({op, result, System.convert_time_unit(duration, :native, :millisecond)})
+        end,
+        nil
+      )
+
+  ## Auth events
+
+  Token fetches emit `[:pubsub_grpc, :auth, _]` events with the same three suffixes.
+  Stop metadata includes `:source` (`:cache | :goth | :gcloud`) when available.
+  """
+
+  @event_prefix [:pubsub_grpc, :request]
+  @auth_event_prefix [:pubsub_grpc, :auth]
+
+  @spec span(atom(), map(), (-> result)) :: result when result: var
+  def span(operation, metadata, fun) when is_atom(operation) and is_map(metadata) do
+    start_meta = Map.put(metadata, :operation, operation)
+
+    :telemetry.span(@event_prefix, start_meta, fn ->
+      result = fun.()
+      {result, Map.put(start_meta, :result, classify(result))}
+    end)
+  end
+
+  @spec auth_span(map(), (-> result)) :: result when result: var
+  def auth_span(metadata, fun) when is_map(metadata) do
+    :telemetry.span(@auth_event_prefix, metadata, fn ->
+      result = fun.()
+      stop_meta = Map.merge(metadata, %{result: classify(result), source: auth_source(result)})
+      {result, stop_meta}
+    end)
+  end
+
+  defp classify(:ok), do: :ok
+  defp classify({:ok, _}), do: :ok
+  defp classify({:error, %PubsubGrpc.Error{code: code}}), do: {:error, code}
+  defp classify({:error, _}), do: {:error, :unknown}
+  defp classify(_), do: :unknown
+
+  defp auth_source({:ok, _}), do: :network
+  defp auth_source(_), do: :unknown
+end

--- a/lib/pubsub_grpc/validation.ex
+++ b/lib/pubsub_grpc/validation.ex
@@ -12,31 +12,47 @@ defmodule PubsubGrpc.Validation do
     {:error, Error.new(:validation_error, "project_id must be a non-empty string")}
   end
 
-  @spec validate_topic_id(term()) :: {:ok, String.t()} | {:error, Error.t()}
-  def validate_topic_id(topic_id) when is_binary(topic_id) and byte_size(topic_id) > 0 do
-    {:ok, topic_id}
-  end
+  # GCP Pub/Sub resource ID rules: start with a letter, 3-255 chars,
+  # letters/digits/dashes/underscores/periods/tildes/plus/percent.
+  # Names beginning with "goog" are reserved.
+  @resource_id_regex ~r/^[A-Za-z][A-Za-z0-9\-_.~+%]{2,254}$/
 
-  def validate_topic_id(_) do
-    {:error, Error.new(:validation_error, "topic_id must be a non-empty string")}
+  @spec validate_topic_id(term()) :: {:ok, String.t()} | {:error, Error.t()}
+  def validate_topic_id(topic_id) do
+    validate_resource_id(topic_id, "topic_id")
   end
 
   @spec validate_subscription_id(term()) :: {:ok, String.t()} | {:error, Error.t()}
-  def validate_subscription_id(sub_id) when is_binary(sub_id) and byte_size(sub_id) > 0 do
-    {:ok, sub_id}
-  end
-
-  def validate_subscription_id(_) do
-    {:error, Error.new(:validation_error, "subscription_id must be a non-empty string")}
+  def validate_subscription_id(sub_id) do
+    validate_resource_id(sub_id, "subscription_id")
   end
 
   @spec validate_schema_id(term()) :: {:ok, String.t()} | {:error, Error.t()}
-  def validate_schema_id(schema_id) when is_binary(schema_id) and byte_size(schema_id) > 0 do
-    {:ok, schema_id}
+  def validate_schema_id(schema_id) do
+    validate_resource_id(schema_id, "schema_id")
   end
 
-  def validate_schema_id(_) do
-    {:error, Error.new(:validation_error, "schema_id must be a non-empty string")}
+  defp validate_resource_id(id, field) when is_binary(id) do
+    cond do
+      not Regex.match?(@resource_id_regex, id) ->
+        {:error,
+         Error.new(
+           :validation_error,
+           "#{field} must start with a letter and be 3-255 chars of " <>
+             "letters/digits/-_.~+%"
+         )}
+
+      String.starts_with?(id, "goog") ->
+        {:error,
+         Error.new(:validation_error, "#{field} must not begin with reserved prefix 'goog'")}
+
+      true ->
+        {:ok, id}
+    end
+  end
+
+  defp validate_resource_id(_, field) do
+    {:error, Error.new(:validation_error, "#{field} must be a string")}
   end
 
   @spec validate_messages(term()) :: {:ok, [map()]} | {:error, Error.t()}
@@ -47,7 +63,7 @@ defmodule PubsubGrpc.Validation do
       {:error,
        Error.new(
          :validation_error,
-         "each message must be a map with :data (binary) and/or :attributes (map)"
+         "each message must be a map with non-empty :data (binary) or non-empty :attributes (map)"
        )}
     end
   end
@@ -126,7 +142,14 @@ defmodule PubsubGrpc.Validation do
 
   # Private
 
-  defp valid_message?(%{data: data}) when is_binary(data), do: true
+  defp valid_message?(%{data: data, attributes: attrs})
+       when is_binary(data) and is_map(attrs) do
+    byte_size(data) > 0 or map_size(attrs) > 0
+  end
+
+  defp valid_message?(%{data: data}) when is_binary(data) and byte_size(data) > 0, do: true
+
   defp valid_message?(%{attributes: attrs}) when is_map(attrs) and map_size(attrs) > 0, do: true
+
   defp valid_message?(_), do: false
 end

--- a/mix.exs
+++ b/mix.exs
@@ -65,6 +65,7 @@ defmodule PubsubGrpc.MixProject do
   defp deps do
     [
       {:grpc_connection_pool, "0.3.0"},
+      {:telemetry, "~> 1.0"},
       {:excoveralls, "~> 0.18", only: :test},
       {:ex_doc, "~> 0.31", only: :dev, runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},

--- a/test/pubsub_grpc/auth_test.exs
+++ b/test/pubsub_grpc/auth_test.exs
@@ -1,6 +1,8 @@
 defmodule PubsubGrpc.AuthTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureLog
+
   alias PubsubGrpc.{Auth, Error}
 
   setup do
@@ -66,6 +68,80 @@ defmodule PubsubGrpc.AuthTest do
       result2 = Auth.request_opts()
 
       assert result1 == result2
+    end
+  end
+
+  describe "credential sanitization" do
+    setup do
+      # Force the non-emulator branch by exercising get_token directly. In emulator
+      # mode request_opts/0 returns {:ok, []} and never touches get_token_fallback.
+      # We invoke get_token/0 with no Goth configured -> goes through gcloud CLI path.
+      saved = Application.get_env(:pubsub_grpc, :goth)
+      Application.delete_env(:pubsub_grpc, :goth)
+      Auth.clear_cache()
+
+      on_exit(fn ->
+        if saved, do: Application.put_env(:pubsub_grpc, :goth, saved)
+        Auth.clear_cache()
+      end)
+
+      :ok
+    end
+
+    test "inspect on an Error does not leak token-bearing details" do
+      # Direct check on the Error struct's Inspect derive — independent of which
+      # auth backend ran.
+      secret_token = "Bearer ya29.SECRET_DO_NOT_LEAK_ME"
+      err = Error.new(:unauthenticated, "auth failed", %{access_token: secret_token})
+
+      refute inspect(err) =~ secret_token
+      refute inspect(err) =~ "access_token"
+    end
+
+    test "auth failure log does not include raw stderr or token-shaped content" do
+      # Capture logs while triggering a gcloud-CLI auth attempt. In CI the call
+      # almost certainly fails — the test verifies that no token-looking material
+      # ends up in the log.
+      log =
+        capture_log(fn ->
+          _ = Auth.get_token()
+        end)
+
+      refute log =~ ~r/Bearer\s+[A-Za-z0-9\.\-_]{20,}/
+      refute log =~ ~r/ya29\.[A-Za-z0-9\.\-_]{10,}/
+    end
+  end
+
+  describe "Goth fallback policy" do
+    setup do
+      saved = Application.get_env(:pubsub_grpc, :goth)
+      # Point at a name that has no registered Goth process.
+      Application.put_env(:pubsub_grpc, :goth, PubsubGrpc.Test.NonExistentGoth)
+      Auth.clear_cache()
+
+      on_exit(fn ->
+        if saved do
+          Application.put_env(:pubsub_grpc, :goth, saved)
+        else
+          Application.delete_env(:pubsub_grpc, :goth)
+        end
+
+        Auth.clear_cache()
+      end)
+
+      :ok
+    end
+
+    test "does not fall back to gcloud when Goth is configured" do
+      # With a bogus Goth name and the cache cleared, get_token/0 must surface
+      # a Goth-flavored error, not silently try the gcloud CLI.
+      log =
+        capture_log(fn ->
+          assert {:error, %Error{code: :unauthenticated, message: message}} = Auth.get_token()
+          refute message =~ "gcloud"
+        end)
+
+      refute log =~ "gcloud CLI auth failed"
     end
   end
 end

--- a/test/pubsub_grpc/error_test.exs
+++ b/test/pubsub_grpc/error_test.exs
@@ -74,4 +74,25 @@ defmodule PubsubGrpc.ErrorTest do
       assert to_string(error) == "[not_found (gRPC 5)] not found"
     end
   end
+
+  describe "Inspect protocol" do
+    test "does not leak :details into inspect output" do
+      secret = "Bearer ya29.SUPER_SECRET_TOKEN_DO_NOT_LEAK"
+      error = Error.new(:unauthenticated, "auth failed", %{token: secret, refresh_path: "/x"})
+
+      inspected = inspect(error)
+
+      refute inspected =~ secret
+      refute inspected =~ "refresh_path"
+      refute inspected =~ "/x"
+      assert inspected =~ ":unauthenticated"
+      assert inspected =~ "auth failed"
+    end
+
+    test "details remains accessible programmatically" do
+      details = %{token: "secret"}
+      error = Error.new(:unauthenticated, "auth failed", details)
+      assert error.details == details
+    end
+  end
 end

--- a/test/pubsub_grpc/telemetry_test.exs
+++ b/test/pubsub_grpc/telemetry_test.exs
@@ -1,0 +1,57 @@
+defmodule PubsubGrpc.TelemetryTest do
+  use ExUnit.Case, async: false
+
+  alias PubsubGrpc.Telemetry
+
+  setup do
+    test_pid = self()
+    handler_id = "test-handler-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [
+        [:pubsub_grpc, :request, :start],
+        [:pubsub_grpc, :request, :stop],
+        [:pubsub_grpc, :request, :exception]
+      ],
+      fn event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    :ok
+  end
+
+  test "span emits start and stop events on success" do
+    result = Telemetry.span(:my_op, %{project_id: "p"}, fn -> {:ok, :payload} end)
+
+    assert result == {:ok, :payload}
+
+    assert_received {:telemetry, [:pubsub_grpc, :request, :start], _measurements,
+                     %{operation: :my_op, project_id: "p"}}
+
+    assert_received {:telemetry, [:pubsub_grpc, :request, :stop], %{duration: d},
+                     %{operation: :my_op, result: :ok}}
+
+    assert is_integer(d) and d >= 0
+  end
+
+  test "span classifies PubsubGrpc.Error in stop metadata" do
+    err = PubsubGrpc.Error.new(:not_found, "missing")
+    _ = Telemetry.span(:get_thing, %{}, fn -> {:error, err} end)
+
+    assert_received {:telemetry, [:pubsub_grpc, :request, :stop], _,
+                     %{operation: :get_thing, result: {:error, :not_found}}}
+  end
+
+  test "span emits exception event when wrapped fun raises" do
+    assert_raise RuntimeError, "boom", fn ->
+      Telemetry.span(:bad, %{}, fn -> raise "boom" end)
+    end
+
+    assert_received {:telemetry, [:pubsub_grpc, :request, :exception], _, %{operation: :bad}}
+  end
+end

--- a/test/pubsub_grpc/validation_test.exs
+++ b/test/pubsub_grpc/validation_test.exs
@@ -33,6 +33,27 @@ defmodule PubsubGrpc.ValidationTest do
     test "rejects nil" do
       assert {:error, %Error{code: :validation_error}} = Validation.validate_topic_id(nil)
     end
+
+    test "rejects names starting with digit" do
+      assert {:error, %Error{code: :validation_error}} = Validation.validate_topic_id("1topic")
+    end
+
+    test "rejects names with disallowed characters" do
+      assert {:error, %Error{code: :validation_error}} = Validation.validate_topic_id("bad/name")
+    end
+
+    test "rejects names below minimum length (3 chars)" do
+      assert {:error, %Error{code: :validation_error}} = Validation.validate_topic_id("ab")
+    end
+
+    test "rejects names exceeding 255 chars" do
+      long = "a" <> String.duplicate("b", 255)
+      assert {:error, %Error{code: :validation_error}} = Validation.validate_topic_id(long)
+    end
+
+    test "rejects reserved 'goog' prefix" do
+      assert {:error, %Error{code: :validation_error}} = Validation.validate_topic_id("googlike")
+    end
   end
 
   describe "validate_subscription_id/1" do
@@ -92,6 +113,21 @@ defmodule PubsubGrpc.ValidationTest do
     test "rejects non-binary data" do
       assert {:error, %Error{code: :validation_error}} =
                Validation.validate_messages([%{data: 123}])
+    end
+
+    test "rejects messages with empty data binary" do
+      assert {:error, %Error{code: :validation_error}} =
+               Validation.validate_messages([%{data: ""}])
+    end
+
+    test "rejects messages with empty data AND empty attributes" do
+      assert {:error, %Error{code: :validation_error}} =
+               Validation.validate_messages([%{data: "", attributes: %{}}])
+    end
+
+    test "accepts empty data when attributes are non-empty" do
+      messages = [%{data: "", attributes: %{"k" => "v"}}]
+      assert {:ok, ^messages} = Validation.validate_messages(messages)
     end
   end
 


### PR DESCRIPTION
## Summary

  Audit-driven hardening pass against `v0.4.1`. Three angles: credential leakage, silent failures, and observability. No public API breakage — `publish` / `pull` / `acknowledge` / `modify_ack_deadline` / `nack`
   gain a backward-compatible trailing `opts` argument for per-call `:timeout`.

  ## Security

  - **`%PubsubGrpc.Error{}` no longer leaks `:details` via `inspect/1`.** Added `@derive {Inspect, only: [:code, :message, :grpc_status]}`. The `details` field is still programmatically accessible — it's just
  invisible to incidental `inspect/1` calls from `Logger`, Sentry, AppSignal, LiveDashboard, etc.
  - **Auth log lines and error messages no longer interpolate sensitive data.** Stopped using `inspect(reason)`, raw `gcloud` stderr, and `Exception.message/1` in user-facing messages. Raw values live in
  `Error.details` only.
  - **Explicit production TLS.** Pool config now passes `[verify: :verify_peer, cacerts: :public_key.cacerts_get()]` instead of `ssl: []`. Override via `config :pubsub_grpc, :ssl_opts, [...]`.

  ## Silent-failure fixes

  - **Goth no longer silently falls back to gcloud CLI.** When `:goth` is explicitly configured, a Goth failure surfaces directly — previously the call slid to `gcloud auth print-access-token`, which could
  succeed on a developer machine as a *different identity* or produce a misleading "gcloud CLI auth failed" error in production. Goth raises/exits are now rescued and caught into a structured error.
  - **Strict app startup.** If both legacy and production config builders fail, `Application.start/2` raises a clear message instead of crashing with a `MatchError` on `{:ok, _} = ...`.
  - **`valid_message?/1` rejects empty messages.** `%{data: ""}`, `%{attributes: %{}}`, and `%{data: "", attributes: %{}}` now fail at the client boundary instead of being sent to Pub/Sub and rejected
  server-side as `INVALID_ARGUMENT`.
  - **Resource-ID regex.** Topic / subscription / schema IDs are validated against the GCP rules (start-with-letter, 3–255 chars, `[A-Za-z0-9\-_.~+%]`) and the reserved `goog` prefix is rejected.

  ## Architecture

  - **Supervised ETS auth cache.** The `:pubsub_grpc_auth_cache` table is now owned by a new `PubsubGrpc.Auth.Cache` GenServer (first child in the supervision tree) instead of being created ad-hoc by the
  Application controller process. Survives Application restarts.
  - **Shared `unwrap_*` helpers.** Duplicated result-unwrapping logic in `PubsubGrpc` and `PubsubGrpc.Schema` extracted to `PubsubGrpc.Result`. Drift risk eliminated; `inspect/_` removed from generated
  messages.

  ## Observability

  - **New `PubsubGrpc.Telemetry` module.** `:telemetry.span/3`-based events on every public RPC:
    - `[:pubsub_grpc, :request, :start | :stop | :exception]` — metadata includes `:operation`, `:project_id`, and (when applicable) `:topic_id`, `:subscription_id`, `:schema_id`, `:message_count`,
  `:ack_count`. Stop metadata adds `:result` (`:ok` or `{:error, error_code}`).
    - `[:pubsub_grpc, :auth, :start | :stop | :exception]` for token fetches, with `:source` (`:goth` / `:gcloud`).
  - **Emulator-mode warning** logged once at application startup.
  - **`:telemetry` is now an explicit dep** (was transitive via `grpc`).

  ## Per-call timeout (L4)

  `publish`, `pull`, `acknowledge`, `modify_ack_deadline`, `nack`, `list_topics`, `list_subscriptions`, `list_schemas`, `get_schema`, `list_schema_revisions`, and `create_subscription` accept `:timeout` in
  their trailing keyword list. Falls back to `config :pubsub_grpc, :default_timeout, 30_000` when unset.

  ## Test plan

  - [x] `mix test` — 142/142 passing (95 unit + 31 emulator-integration + 16 new)
  - [x] `mix credo --strict` — exits 0 (21 nesting-depth refactor *suggestions* remain from the telemetry-wrap pattern; non-blocking)
  - [x] `mix compile --warnings-as-errors` — clean
  - [x] New tests cover: empty-message rejection, `Error` inspect redaction, Goth no-fallback policy, auth log sanitization (`capture_log`), ID regex validation, telemetry event emission
  - [ ] Smoke test against a real GCP project (reviewer / maintainer)

  ## Notes for reviewers

  - API surface is additive: every public function keeps its prior arities; new opts are trailing with `\\ []` defaults.
  - The 21 credo flags are all `Refactor.Nesting` warnings of the form *"nested too deep (max depth is 2, was 3)"*. They come from `Telemetry.span(:op, %{...}, fn -> with ... end end)`. If you want them gone,
  the clean fix is to extract per-function `defp do_<name>(...)` helpers — mechanical but ~20 functions of churn. Happy to push a follow-up.
  - Suggests a `0.4.2` bump (no breaking changes) or `0.5.0` if you want to signal the telemetry surface as a new feature.
